### PR TITLE
Add photo to start welcome message

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -322,6 +322,7 @@ async def cmd_start(m: Message):
     kb.button(text=tr(lang, 'btn_chat'),   callback_data='pay:chat')
     kb.button(text=tr(lang, 'btn_donate'), callback_data='donate')
     kb.adjust(1)
+    await m.answer_photo("https://i.postimg.cc/15nfSDwL/temp-Imageaj-TSoh.avif")
     await m.answer(tr(lang, 'menu', name=m.from_user.first_name), reply_markup=kb.as_markup())
 
 @main_r.callback_query(F.data == 'live')


### PR DESCRIPTION
## Summary
- show promo photo before text in /start handler

## Testing
- `python -m py_compile juicyfox_bot_single.py`

------
https://chatgpt.com/codex/tasks/task_e_687224f7846c832a88418f71e549caae