### PR TITLE
Add VIP Secret description

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -130,7 +130,8 @@ L10N={
   'cancel':'❌ Тогда в другой раз…😔',
   'nothing_cancel':'Нечего отменять.',
 'desc_club': 'Luxury Room – Juicy Fox\n💎 Моя премиальная коллекция эротики создана для ценителей женской роскоши! 🔥 За символические 15 $ ты получишь контент без цензуры 24/7×30 дней 😈',
- 'luxury_desc': 'Luxury Room – Juicy Fox\n💎 Моя премиальная коллекция эротики создана для ценителей женской роскоши! 🔥 За символические 15 $ ты получишь контент без цензуры на 30 дней😈'
+ 'luxury_desc': 'Luxury Room – Juicy Fox\n💎 Моя премиальная коллекция эротики создана для ценителей женской роскоши! 🔥 За символические 15 $ ты получишь контент без цензуры на 30 дней😈',
+ 'vip_secret_desc': 'Твой личный доступ в VIP Secret от Juicy Fox 😈\n🔥Тут всё, о чём ты фантазировал:\n📸 больше HD фото нюдс крупным планом 🙈\n🎥 Видео, где я играю со своей киской 💦\n💬 Juicy Chat — где я отвечаю тебе лично, кружочками 😘\n📆 Период: 30 дней\n💸 Стоимость: 35$\n💳💵💱 — выбери, как тебе удобнее'
  },
  'en':{
   'menu': """Hey, {name} 😘 I’m your Juicy Fox tonight 🦊
@@ -153,7 +154,8 @@ Open Juicy Chat 💬 — and I’ll be waiting inside 💌""",
   'cancel':'❌ Maybe next time…😔',
   'nothing_cancel':'Nothing to cancel.',
   'back': '🔙 Back',
-  'luxury_desc': 'Luxury Room – Juicy Fox\n💎 My premium erotica collection is made for connoisseurs of feminine luxury! 🔥 For just $15 you’ll get uncensored content for 30 days 😈'
+  'luxury_desc': 'Luxury Room – Juicy Fox\n💎 My premium erotica collection is made for connoisseurs of feminine luxury! 🔥 For just $15 you’ll get uncensored content for 30 days 😈',
+  "vip_secret_desc": "Your personal access to Juicy Fox’s VIP Secret 😈\n🔥 Everything you've been fantasizing about:\n📸 More HD Photo close-up nudes 🙈\n🎥 Videos where I play with my pussy 💦\n💬 Juicy Chat — where I reply to you personally, with video-rols 😘\n📆 Duration: 30 days\n💸 Price: $35\n💳💵💱 — choose your preferred payment method"
  },
 'es': {
   'menu': """Hola, {name} 😘 Esta noche soy tu Juicy Fox 🦊
@@ -175,7 +177,8 @@ Haz clic en Juicy Chat 💬 — y te espero adentro 💌""",
   'cancel': '❌ Quizás en otro momento… 😔',
   'nothing_cancel': 'No hay nada que cancelar.',
   'back': '🔙 Back',
-  'luxury_desc': 'Luxury Room – Juicy Fox\n💎 ¡Mi colección de erotismo premium está creada para los amantes del lujo femenino! 🔥 Por solo 15 $ obtendrás contenido sin censura 30 días 😈'
+  'luxury_desc': 'Luxury Room – Juicy Fox\n💎 ¡Mi colección de erotismo premium está creada para los amantes del lujo femenino! 🔥 Por solo 15 $ obtendrás contenido sin censura 30 días 😈',
+  'vip_secret_desc': "Tu acceso personal al VIP Secret de Juicy Fox 😈\n🔥 Todo lo que has estado fantaseando:\n📸 Más fotos HD de mis partes íntimas en primer plano 🙈\n🎥 Videos donde juego con mi Coño 💦\n💬 Juicy Chat — donde te respondo personalmente con videomensajes 😘\n📆 Duración: 30 días\n💸 Precio: 35$\n💳💵💱 — elige tu forma de pago preferida"
   }
 }
 
@@ -230,7 +233,10 @@ async def choose_cur(cq: CallbackQuery):
     kb.adjust(2)
     if plan == 'club':
         lang = cq.from_user.language_code
-        text = L10N.get(lang, L10N["en"])['luxury_desc']
+        text = L10N.get(lang, L10N['en'])['luxury_desc']
+    elif plan in ('vip_secret', 'vip'):
+        lang = cq.from_user.language_code
+        text = L10N.get(lang, L10N['en'])['vip_secret_desc']
     else:
         text = tr(cq.from_user.language_code, 'choose_cur', amount=amt)
     await cq.message.edit_text(text, reply_markup=kb.as_markup())


### PR DESCRIPTION
## Summary
- add `vip_secret_desc` localization strings in ru/en/es
- display VIP Secret description before currency choice

## Testing
- `python -m py_compile juicyfox_bot_single.py`


------
https://chatgpt.com/codex/tasks/task_e_68729501b4e0832aae224f63076835c4