### PR TITLE
Refactor header to remove profile link

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -526,7 +526,8 @@ async def relay_private(msg: Message):
     flag = {
         'ru': '🇷🇺', 'en': '🇺🇸', 'tr': '🇹🇷', 'de': '🇩🇪'
     }.get(msg.from_user.language_code[:2], '🏳️')
-    header = (f"[{msg.from_user.first_name}](tg://user?id={msg.from_user.id}) "
+    username = msg.from_user.username or "User"
+    header = (f"{username} "
               f"• до {expires} • 💰 ${donated:.2f} • <code>{msg.from_user.id}</code> • {flag}")
 
     header_msg = await bot.send_message(CHAT_GROUP_ID, header, parse_mode="HTML")


### PR DESCRIPTION
## Summary
- display username without clickable profile link in relay header

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876b8cab978832ab404fd1a6a87a0b7