### PR TITLE
Fix env-based channel mapping

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -57,9 +57,9 @@ LUXURY_CHANNEL_ID = int(os.getenv('LUXURY_CHANNEL_ID', '-1002808420871'))
 POST_PLAN_CHANNEL_ID = int(os.getenv('POST_PLAN_CHANNEL_ID', '-1002791131375'))
 
 CHANNELS = {
-  "life": -1000000000000,
-  "luxury": -1000000000000,
-  "vip": -1000000000000,
+  "life": int(os.getenv("LIFE_CHANNEL_ID")),
+  "luxury": int(os.getenv("LUXURY_CHANNEL_ID")),
+  "vip": int(os.getenv("VIP_CHANNEL_ID")),
 }
 
 if not TELEGRAM_TOKEN or not CRYPTOBOT_TOKEN:


### PR DESCRIPTION
## Summary
- use real channel IDs from env

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68778609d7bc832aa5e7edf2fed59adb