### PR TITLE
Fix on_startup signature

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -667,7 +667,7 @@ async def scheduled_poster():
             except Exception:
                 continue
 
-async def on_startup(_):
+async def on_startup(_: Dispatcher):
     asyncio.create_task(scheduled_poster())
 
 dp.startup.register(on_startup)


### PR DESCRIPTION
## Summary
- fix `on_startup` signature so aiogram passes dispatcher instance

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877ce4a8a58832aae0f9253090a59d8