### PR TITLE
Log scheduled poster start

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -664,6 +664,7 @@ async def debug_all_channel_posts(msg: Message):
     log.info("[DEBUG] Got channel post in %s: %s", msg.chat.id, msg.text or "<media>")
 
 async def scheduled_poster():
+    log.info("[POSTING PLAN] Стартовал планировщик scheduled_poster")
     while True:
         await asyncio.sleep(10)
         now = int(time.time())


### PR DESCRIPTION
## Summary
- add a startup log to `scheduled_poster`
- verify `on_startup` registers `scheduled_poster`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a1eaa895c832abc735a4555c766cb