### PR TITLE
Add message availability check in scheduled_poster

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -689,6 +689,17 @@ async def scheduled_poster():
                 text,
             )
             try:
+                await bot.get_chat(from_chat)
+                await bot.get_message(from_chat, from_msg)
+            except Exception as e:
+                log.error(
+                    "[JFB PLAN] Проверка сообщения %s из %s: недоступно (%s)",
+                    from_msg,
+                    from_chat,
+                    e,
+                )
+                continue
+            try:
                 await bot.copy_message(chat_id, from_chat, from_msg, caption=text)
             except Exception as e:
                 log.error("[JFB PLAN] Ошибка при отправке в %s: %s", channel, e)


### PR DESCRIPTION
## Summary
- check message availability in `scheduled_poster` before copying

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b502ebb14832ab660295b7d227df9