### PR TITLE
Temporary send_message for debugging

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -700,7 +700,7 @@ async def scheduled_poster():
                 )
                 continue
             try:
-                await bot.copy_message(chat_id, from_chat, from_msg, caption=text)
+                await bot.send_message(chat_id, text or "<empty>")
             except Exception as e:
                 log.error("[JFB PLAN] Ошибка при отправке в %s: %s", channel, e)
                 continue


### PR DESCRIPTION
## Summary
- temporarily replace `bot.copy_message` with `bot.send_message` in the scheduled poster to diagnose message access errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b542c345c832aab8e7ff6c61a35ae