### PR TITLE
Improve debug logs for scheduled poster

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -688,6 +688,8 @@ async def scheduled_poster():
                 channel,
                 text,
             )
+            log.info(f"[DEBUG] Extracted tag: {channel}, chat_id: {chat_id}")
+            log.info(f"[DEBUG] Will try to copy message {from_msg} from {from_chat}")
             try:
                 await bot.get_chat(from_chat)
                 # await bot.get_message(from_chat, from_msg)
@@ -701,8 +703,9 @@ async def scheduled_poster():
                 continue
             try:
                 await bot.copy_message(chat_id, from_chat, from_msg, caption=text)
+                log.info(f"[DEBUG] Message copied to {channel}")
             except Exception as e:
-                log.error("[JFB PLAN] Ошибка при отправке в %s: %s", channel, e)
+                log.exception(f"[ERROR] Failed to copy to {channel}: {e}")
                 await bot.send_message(chat_id, text if text else "[пусто]")
                 continue
             await _db_exec("DELETE FROM scheduled_posts WHERE rowid=?", rowid)


### PR DESCRIPTION
## Summary
- log target tag and chat id before copying posts
- log success or failure when copying messages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687b79124030832a8b164b02d8ae12bb