### PR TITLE
Remove VIP posting check

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -685,11 +685,6 @@ async def scheduled_poster():
         )
 
         for rowid, _, channel, price, text, from_chat, from_msg in rows:
-            if channel in {'vip', 'luxury'}:
-                # Проверка наличия оплаты для VIP/Luxury
-                if not await is_paid_for(CHAT_GROUP_ID, channel):
-                    log.warning(f"[SKIP] Нет доступа к {channel}")
-                    continue
             log.info(
                 "[JFB PLAN] Проверка сообщения %s из %s",
                 from_msg,


### PR DESCRIPTION
## Summary
- remove VIP/Luxury paywall from scheduled_poster so the bot always posts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687be1f61d64832aab9b4a5a72742951