### PR TITLE
Fix post plan caption priority

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -688,7 +688,7 @@ async def handle_posting_plan(msg: Message):
         await msg.reply("⛔️ Только админ может планировать посты.")
         return
 
-    text = msg.text or msg.caption
+    text = msg.caption or msg.text
     if not text:
         return
 


### PR DESCRIPTION
## Summary
- adjust posting plan handler to parse caption before text when scheduling posts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d470838f4832a8dfd637fc884ef25