### PR TITLE
Block chat posts from scheduler

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -759,6 +759,11 @@ async def scheduled_poster():
             if not chat_id:
                 log.warning(f"[SCHEDULED_POSTER] Channel {channel} not found in CHANNELS, skipping rowid={rowid}")
                 continue
+            # Block sending to CHAT_GROUP_ID from scheduler
+            if chat_id == CHAT_GROUP_ID:
+                log.warning(f"[SCHEDULED_POSTER] Posting to CHAT_GROUP_ID is forbidden, skipping rowid={rowid}")
+                await _db_exec("DELETE FROM scheduled_posts WHERE rowid=?", rowid)
+                continue
             log.debug(f"[DEBUG] Ready to post: rowid={rowid} channel={channel} text={text[:30]}")
             try:
                 await bot.copy_message(chat_id, from_chat, from_msg, caption=text)


### PR DESCRIPTION
## Summary
- prevent scheduler from sending messages to CHAT_GROUP_ID
- ensure only life, luxury, vip are valid plan targets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d559d6214832aa40c2b7d341117bb