### PR TITLE
Fix scheduler text post logic

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -828,6 +828,9 @@ async def scheduled_poster():
                                 m = InputMediaVideo(media=file_id, caption=text if i == 0 else None)
                             media.append(m)
                         await bot.send_media_group(chat_id, media)
+                elif not media_ids and text:
+                    # Если только текст — отправить текстовое сообщение
+                    await bot.send_message(chat_id, text)
                 elif text == '<media>' or not text:
                     await bot.copy_message(chat_id, from_chat, from_msg)
                 else:


### PR DESCRIPTION
## Summary
- ensure scheduled text-only posts send as messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e043cc254832ab44a432512128da3