### PR TITLE
Fix delete_post to match channels by chat_id

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -857,7 +857,7 @@ async def scheduled_poster():
                     await _db_exec(
                         "INSERT INTO published_posts VALUES(?,?,?)",
                         rowid,
-                        channel,
+                        chat_id,
                         ','.join(sent_ids),
                     )
             except TelegramBadRequest as e:
@@ -973,8 +973,7 @@ async def delete_post_cmd(msg: Message):
         if not row:
             await msg.reply("❌ Пост не найден")
             return
-        channel, message_id = row
-    chat_id = CHANNELS.get(channel)
+        chat_id, message_id = row
     try:
         for mid in str(message_id).split(','):
             await bot.delete_message(chat_id, int(mid))


### PR DESCRIPTION
## Summary
- fix channel matching for `delete_post`
- store actual chat_id when logging published posts

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e7c81cd74832aa6bb6adfe5e3875d