### PR TITLE
Remove chat from auto-posting options

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -26,7 +26,6 @@ def get_post_plan_kb():
     kb.button(text="👀 Life", callback_data="post_to:life")
     kb.button(text="💿 Luxury", callback_data="post_to:luxury")
     kb.button(text="👑 VIP", callback_data="post_to:vip")
-    kb.button(text="💬 Chat", callback_data="post_to:chat")
     kb.adjust(2)
     return kb.as_markup()
 


### PR DESCRIPTION
## Summary
- disallow scheduling posts to the chat group by omitting it from the posting-plan keyboard
- scheduled poster already rejects posts targeting `CHAT_GROUP_ID`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f84b9a60c832a92ddc3211e5ba107