### PR TITLE
Restore group reply relay

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -610,14 +610,9 @@ async def relay_private(msg: Message):
 # ---------------- Group → user relay ----------------------
 @dp.message(F.chat.id == CHAT_GROUP_ID)
 async def relay_group(msg: Message):
-    if (
-        msg.reply_to_message and
-        msg.reply_to_message.message_id in relay and
-        msg.from_user.id in [admin.user.id for admin in await msg.chat.get_administrators()]
-    ):
+    if msg.reply_to_message and msg.reply_to_message.message_id in relay:
         uid = relay[msg.reply_to_message.message_id]
-        await bot.copy_message(uid, CHAT_GROUP_ID, msg.message_id)
-        await _db_exec('INSERT INTO messages VALUES(?,?,?,?)', int(time.time()), uid, msg.message_id, 1)
+        await bot.send_message(uid, msg.text)
 
 @dp.message(Command('history'))
 async def history_request(msg: Message):


### PR DESCRIPTION
## Summary
- restore simple relay via dict
- relay replies from group chat directly to user

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687f90299588832a97a6c4094776df66