### PR TITLE
Add webhook setup on startup

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -6,6 +6,11 @@
 # • RU/EN/ES UI           → auto by language_code
 
 import os, logging, asyncio, httpx, time, aiosqlite, traceback
+import asyncio
+import aiohttp
+from os import getenv
+from aiogram import Bot
+from aiogram.client.session.aiohttp import AiohttpSession
 from datetime import datetime
 DB_PATH = '/app/messages.sqlite'
 
@@ -994,7 +999,14 @@ async def delete_post_cmd(msg: Message):
     except Exception as e:
         await msg.reply(f"❌ Ошибка удаления: {e}")
 
+async def setup_webhook():
+    session = AiohttpSession()
+    bot = Bot(token=getenv("TELEGRAM_TOKEN"), session=session)
+    webhook_url = getenv("WEBHOOK_URL")
+    await bot.set_webhook(webhook_url)
+
 if __name__ == '__main__':
+    asyncio.run(setup_webhook())
     print("DEBUG: JuicyFox main() will run")
     asyncio.run(main())
 


### PR DESCRIPTION
## Summary
- import aiohttp classes and utilities
- setup webhook before running bot

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688371a22c20832abfd01125936d06f7