### PR TITLE
Add FastAPI and Uvicorn deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ httpx
 aiosqlite
 gunicorn
 fastapi
+fastapi
+uvicorn[standard]


### PR DESCRIPTION
## Summary
- add FastAPI and Uvicorn standard dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688394656aa4832a9023d95487c4b28d