### PR TITLE
Fix FastAPI entry point in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ COPY . .
 
 # Запуск FastAPI
 EXPOSE 8080
-CMD ["gunicorn", "api.main:app", "--worker-class", "uvicorn.workers.UvicornWorker", "--bind", "0.0.0.0:8080"]
+CMD ["gunicorn", "main:app", "--worker-class", "uvicorn.workers.UvicornWorker", "--bind", "0.0.0.0:8080"]
 VOLUME /data


### PR DESCRIPTION
## Summary
- update the `CMD` instruction in `Dockerfile` to start `main:app`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68839d8b2ce4832a97d7b43da640c70f