### PR TITLE
Fix import path for FastAPI logs

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 import asyncio
 from juicyfox_bot_single import main as run_bot
-from check_logs import get_logs_clean, get_logs_full
+from api.check_logs import get_logs_clean, get_logs_full
 
 app = FastAPI()
 


### PR DESCRIPTION
## Summary
- use `api.check_logs` for logs import in `api/main.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883a84eee28832a860f8a3a00abd0b9