### PR TITLE
Fix port for FastAPI and remove duplicate dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ COPY . .
 
 # Запуск FastAPI
 EXPOSE 8080
-CMD ["gunicorn", "api.main:app", "--worker-class", "uvicorn.workers.UvicornWorker", "--bind", "0.0.0.0:8080"]
+CMD ["gunicorn", "api.main:app", "--worker-class", "uvicorn.workers.UvicornWorker", "--bind", "0.0.0.0:8000"]
 VOLUME /data

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,4 @@ httpx
 aiosqlite
 gunicorn
 fastapi
-fastapi
 uvicorn[standard]


### PR DESCRIPTION
FastAPI переведён на порт 8000 для устранения конфликта с aiohttp-сервером бота. Удалён дубликат FastAPI в зависимостях.

------
https://chatgpt.com/codex/tasks/task_e_6883b202f40c832abc05591bf2ceebf3