### PR TITLE
Restore /logs full endpoint

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 import asyncio
 from juicyfox_bot_single import main as run_bot
-from check_logs import get_logs_clean
+from api.check_logs import get_logs_clean, get_logs_full
 
 app = FastAPI()
 
@@ -19,5 +19,5 @@ async def clean_logs():
     return await get_logs_clean()
 
 @app.get("/logs")
-async def fetch_logs():
-    return await get_logs_clean()
+async def full_logs():
+    return await get_logs_full()


### PR DESCRIPTION
## Summary
- fix import path to include `get_logs_full`
- return previous `/logs` endpoint that uses full logs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883be2fb81c832aa16a2d955bef1cb5