### PR TITLE
Add public log endpoints

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -2,9 +2,17 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 import asyncio
 from juicyfox_bot_single import main as run_bot
-from api.check_logs import get_logs_clean, get_logs_full
+from check_logs import get_logs_clean, get_logs_full
 
 app = FastAPI(default_response_class=JSONResponse)
+
+@app.get("/logs")
+async def full_logs():
+    return await get_logs_full()
+
+@app.get("/logs/clean")
+async def clean_logs():
+    return await get_logs_clean()
 
 @app.on_event("startup")
 async def startup_event():
@@ -14,11 +22,3 @@ async def startup_event():
 @app.get("/")
 async def root():
     return {"message": "FastAPI работает! 🎉"}
-
-@app.get("/logs/clean")
-async def clean_logs():
-    return await get_logs_clean()
-
-@app.get("/logs")
-async def full_logs():
-    return await get_logs_full()


### PR DESCRIPTION
## Summary
- import log functions from `check_logs`
- expose `/logs` and `/logs/clean` endpoints via FastAPI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883d993db44832aa3c033c4e595c136