### PR TITLE
Store post identifiers for removal

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -877,8 +877,8 @@ async def scheduled_poster():
                 if published:
                     await _db_exec(
                         "INSERT INTO published_posts (chat_id, message_id) VALUES (?, ?)",
-                        chat_id,
-                        ','.join(sent_ids),
+                        published.chat.id,
+                        published.message_id,
                     )
             except TelegramBadRequest as e:
                 log.warning(f"[POST FAIL] {e}")


### PR DESCRIPTION
## Summary
- record channel and message identifiers after posting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884b2ffebd8832aa1e8edcf74d3f82f