### PR TITLE
Configure runtime logging file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,10 @@ If you plan to use packages from GitHub (e.g. `git+https://github.com/...`), mak
 ```
 
 Где `<id>` — номер поста из уведомления бота после публикации.
+
+## Setup
+
+```bash
+mkdir -p logs
+touch logs/runtime.log
+```

--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -60,8 +60,14 @@ async def _init_db():
 
 
 import os
-logging.basicConfig(level=logging.DEBUG)
+os.makedirs("logs", exist_ok=True)
+logging.basicConfig(
+    filename="logs/runtime.log",
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s"
+)
 log = logging.getLogger(__name__)
+logging.info("\ud83d\udd25 Bot launched successfully")
 
 # ---------------- Config ----------------
 TELEGRAM_TOKEN  = os.getenv('TELEGRAM_TOKEN')


### PR DESCRIPTION
## Summary
- create `logs/runtime.log`
- log to `logs/runtime.log` and record startup message
- document log setup instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884e7a7c7b0832ab2546e59b7955708