### PR TITLE
Split start menu messages

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -597,9 +597,19 @@ async def cmd_start(m: Message):
     )
     await m.answer_photo(
         photo="https://files.catbox.moe/cqckle.jpg",
-        caption=tr(lang, 'menu', name=m.from_user.first_name),
-        reply_markup=reply_kb
+        caption=tr(lang, 'menu', name=m.from_user.first_name)
     )
+
+    kb = InlineKeyboardBuilder()
+    kb.button(text=tr(lang, 'btn_life'), callback_data='life')
+    kb.button(text=tr(lang, 'btn_club'), callback_data='pay:club')
+    kb.button(text=tr(lang, 'btn_vip'), callback_data='pay:vip')
+    kb.button(text=tr(lang, 'btn_donate'), callback_data='donate')
+    kb.button(text=tr(lang, 'btn_chat'), callback_data='pay:chat')
+    kb.adjust(1)
+    await m.answer("⬇️", reply_markup=kb.as_markup())
+
+    await m.answer("⬇️", reply_markup=reply_kb)
 
 @main_r.callback_query(F.data == 'life')
 async def life_link(cq: CallbackQuery):


### PR DESCRIPTION
## Summary
- separate the welcome photo from the inline keyboard
- keep reply keyboard at the bottom

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6886516fc954832a8f12fd6e67038480