### PR TITLE
Fix inline menu arrow

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -611,7 +611,7 @@ async def cmd_start(m: Message):
     )
 
     await m.answer(
-        text="⬇️",
+        text="",
         reply_markup=reply_kb
     )
 


### PR DESCRIPTION
## Summary
- update main menu to omit extra arrow message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68865fb9b5b0832aba1335d6afd74386