### PR TITLE
Fix inline keyboard menu

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -610,11 +610,6 @@ async def cmd_start(m: Message):
         reply_markup=kb.as_markup()
     )
 
-    await m.answer(
-        text="",
-        reply_markup=reply_kb
-    )
-
 @main_r.callback_query(F.data == 'life')
 async def life_link(cq: CallbackQuery):
     kb = InlineKeyboardBuilder()


### PR DESCRIPTION
## Summary
- remove extra message after the welcome photo to keep inline buttons functional

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688662ecaedc832ab982307d95d70f7e