### PR TITLE
Add reply kb on /start

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -610,6 +610,11 @@ async def cmd_start(m: Message):
         reply_markup=kb.as_markup()
     )
 
+    await m.answer(
+        text=tr(lang, 'life_link', url=LIFE_URL),
+        reply_markup=reply_kb
+    )
+
 @main_r.callback_query(F.data == 'life')
 async def life_link(cq: CallbackQuery):
     kb = InlineKeyboardBuilder()


### PR DESCRIPTION
## Summary
- show reply keyboard with subscription links after /start

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6886aeffbc1c832aa3774e3b1d0db57c