### PR TITLE
Remove inline buttons from photo

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -610,7 +610,6 @@ async def cmd_start(m: Message):
     await m.answer_photo(
         photo="https://files.catbox.moe/cqckle.jpg",
         caption=tr(lang, 'menu', name=m.from_user.first_name),
-        reply_markup=kb.as_markup()
     )
 
     await m.answer(


### PR DESCRIPTION
## Summary
- remove extra inline keyboard from startup photo

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68876e2f6f40832aa6a2840596ba4b3b