### PR TITLE
Remove auto inline menu

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -623,10 +623,6 @@ async def cmd_start(m: Message):
         caption=tr(lang, 'menu', name=m.from_user.first_name),
     )
 
-    await m.answer(
-        tr(lang, 'choose_action'),
-        reply_markup=kb.as_markup()
-    )
 
     await m.answer(
         text=tr(lang, 'life_link', url=LIFE_URL),


### PR DESCRIPTION
## Summary
- remove automatically showing the inline menu in `/start`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887aec83474832a9ae18d7ad890b451