### PR TITLE
Remove subscribe button

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -293,8 +293,8 @@ L10N={
   'btn_vip':'❤️‍🔥 VIP Secret - 35 $',
   'btn_chat':'💬 Juicy Chat',
   'btn_donate':'🎁 Custom',
-  'btn_tip': '🛍 Tip Menu',
-  'activate_chat_btn':'Активировать Juicy Chat 💬', 'subscribe_life_btn':'Подписаться на Juicy Life 👀', 'life_link':'👀 Мой канал: {url}', 'my_channel': '👀 Мой бесплатный канал: {link}',
+  'tip_menu': '🛍 Tip Menu',
+  'activate_chat':'Активировать Juicy Chat 💬', 'life_link':'👀 Мой канал: {url}', 'my_channel': '👀 Мой бесплатный канал: {link}',
   'choose_action': 'Выбери действие ниже:',
   'choose_cur':'🧁 Готов побаловать меня? Выбери валюту 🛍️ ({amount}$)',
   'don_enter':'💸 Введи сумму в USD (5/10/25/50/100/200)',
@@ -335,8 +335,8 @@ Don’t forget to follow my free channel 👇🏼👇🏼👇🏼""",
   'btn_vip':'❤️‍🔥  VIP Secret - 35 $',
   'btn_chat':'💬 Juicy Chat',
   'btn_donate':'🎁 Custom',
-  'btn_tip': '🛍 Tip Menu',
-  'activate_chat_btn':'Activate Juicy Chat 💬', 'subscribe_life_btn':'Subscribe to Juicy Life 👀', 'life_link':'👀 My channel: {url}', 'my_channel': '👀 My free channel: {link}',
+  'tip_menu': '🛍 Tip Menu',
+  'activate_chat':'Activate Juicy Chat 💬', 'life_link':'👀 My channel: {url}', 'my_channel': '👀 My free channel: {link}',
   'choose_action': 'Choose an action below:',
   'choose_cur':'🧁 Ready to spoil me? Pick a currency 🛍️ ({amount}$)',
   'don_enter':'💸 Enter amount in USD (5/10/25/50/100/200)',
@@ -377,8 +377,8 @@ No olvides suscribirte a mi canal gratis 👇🏼👇🏼👇🏼""",
   'btn_vip': '❤️‍🔥 VIP Secret - 35 $',
   'btn_chat': '💬 Juicy Chat',
   'btn_donate': '🎁 Custom',
-  'btn_tip': '🛍 Tip Menu',
-  'activate_chat_btn':'Activar Juicy Chat 💬', 'subscribe_life_btn':'Suscribirse a Juicy Life 👀', 'life_link':'👀 Mi canal: {url}', 'my_channel': '👀 Mi canal gratuito: {link}',
+  'tip_menu': '🛍 Tip Menu',
+  'activate_chat':'Activar Juicy Chat 💬', 'life_link':'👀 Mi canal: {url}', 'my_channel': '👀 Mi canal gratuito: {link}',
   'choose_action': 'Elige una acción abajo:',
   'choose_cur': '🧁 ¿Listo para consentirme? Elige una moneda 🛍️ ({amount}$)',
   'don_enter': '💸 Introduce el monto en USD (5/10/25/50/100/200)',
@@ -609,9 +609,8 @@ async def cmd_start(m: Message):
     lang = m.from_user.language_code
     reply_kb = ReplyKeyboardMarkup(
         keyboard=[
-            [KeyboardButton(text=tr(lang, 'activate_chat_btn'))],
-            [KeyboardButton(text=tr(lang, 'subscribe_life_btn'))],
-            [KeyboardButton(text=tr(lang, 'btn_tip'))]
+            [KeyboardButton(text=tr(lang, 'activate_chat'))],
+            [KeyboardButton(text=tr(lang, 'tip_menu'))]
         ],
         resize_keyboard=True
     )
@@ -655,7 +654,7 @@ async def tip_menu(cq: CallbackQuery):
     await cq.message.answer(tr(lang, 'choose_action'), reply_markup=kb.as_markup())
 
 
-@dp.message(lambda msg: msg.text == tr(msg.from_user.language_code, 'activate_chat_btn'))
+@dp.message(lambda msg: msg.text == tr(msg.from_user.language_code, 'activate_chat'))
 async def handle_chat_btn(msg: Message, state: FSMContext):
     lang = msg.from_user.language_code
     await state.set_state(ChatGift.plan)
@@ -665,13 +664,9 @@ async def handle_chat_btn(msg: Message, state: FSMContext):
     )
 
 
-@dp.message(lambda msg: msg.text == tr(msg.from_user.language_code, 'subscribe_life_btn'))
-async def handle_life_btn(msg: Message):
-    lang = msg.from_user.language_code
-    await msg.answer(tr(lang, 'my_channel', link=LIFE_URL))
 
 
-@dp.message(lambda msg: msg.text == tr(msg.from_user.language_code, 'btn_tip'))
+@dp.message(lambda msg: msg.text == tr(msg.from_user.language_code, 'tip_menu'))
 async def handle_tip_menu(msg: Message):
     lang = msg.from_user.language_code
     kb = build_tip_menu(lang)


### PR DESCRIPTION
## Summary
- drop the "subscribe" menu button from `ReplyKeyboardMarkup`
- remove unused handler and translations
- rename chat/tip menu keys in `L10N`

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887bfd7d880832a9defa19dd6479860