### PR TITLE
Ensure message database persists across deployments

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -12,8 +12,8 @@ from os import getenv
 from aiogram import Bot
 from aiogram.client.session.aiohttp import AiohttpSession
 from datetime import datetime
-DB_PATH = '/app/data/messages.sqlite'
-os.makedirs('/app/data', exist_ok=True)
+DB_PATH = os.path.abspath(os.getenv('DB_PATH', '/app/data/messages.sqlite'))
+os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
 
 if not os.path.exists(DB_PATH):
     with sqlite3.connect(DB_PATH) as db:


### PR DESCRIPTION
## Summary
- guarantee message history persists by storing database at `/app/data/messages.sqlite`
- create parent folder if missing and reuse existing database

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892385e1668832a8c4cc6c15ef8e2c2