### PR TITLE
Handle empty operator media messages

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -836,7 +836,7 @@ async def relay_group(msg: Message, state: FSMContext, **kwargs):
 
         file_id = None
         media_type = None
-        text = msg.text or msg.caption
+        text = msg.text or msg.caption or ''
 
         if msg.photo:
             file_id = msg.photo[-1].file_id


### PR DESCRIPTION
## Summary
- Ensure operator messages fallback to empty text when both text and caption are missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68933379db2c832a8ea7aa016e225f94