### PR TITLE
Add Post Plan button to admin media

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -1258,6 +1258,19 @@ async def delete_post_cmd(msg: Message):
     except Exception as e:
         print(f"❌ Ошибка удаления: {e}")
 
+
+@dp.message(F.chat.id == POST_PLAN_GROUP_ID)
+async def postgroup_media_handler(msg: Message):
+    if msg.from_user.id not in ADMINS:
+        return
+    if not (msg.photo or msg.video):
+        return
+
+    kb = InlineKeyboardMarkup(inline_keyboard=[[
+        InlineKeyboardButton(text="📆 Post Plan", callback_data=f"plan:{msg.message_id}")
+    ]])
+    await msg.edit_reply_markup(reply_markup=kb)
+
 async def setup_webhook():
     session = AiohttpSession()
     bot = Bot(token=getenv("TELEGRAM_TOKEN"), session=session)


### PR DESCRIPTION
## Summary
- add handler to append "📆 Post Plan" button to admin photo/video messages in post group

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894893abd18832ab3b6cf351dea44b3