### PR TITLE
refactor: log unsupported post-plan content

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -996,8 +996,8 @@ async def post_plan_button(msg: Message):
         return
 
     if not (msg.photo or msg.video or msg.animation):
-        log.error(
-            "[POST_PLAN_BTN] Unsupported content user=%s chat=%s type=%s",
+        log.info(
+            "[POST_PLAN_BTN] Ignoring unsupported content user=%s chat=%s type=%s",
             user_id,
             msg.chat.id,
             msg.content_type,


### PR DESCRIPTION
## Summary
- use log.info when ignoring unsupported post-plan content types

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895df88cf78832aa284297e5e7aab2c