### PR TITLE
Prevent duplicate album buttons in post-plan handler

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -987,6 +987,8 @@ async def _unused_cmd_history_3(msg: Message):
         except Exception as e:
             print(f"Ошибка при отправке истории: {e}")
 
+post_plan_albums: set[str] = set()
+
 @dp.message(F.chat.id == int(POST_PLAN_GROUP_ID))
 async def post_plan_button(msg: Message):
     """Attach a planning button to media posts in the post-plan group."""
@@ -1003,6 +1005,31 @@ async def post_plan_button(msg: Message):
             msg.content_type,
         )
         return
+
+    album_id = msg.media_group_id
+    if album_id:
+        if album_id in post_plan_albums:
+            log.info(
+                "[POST_PLAN_BTN] Album already handled user=%s chat=%s album=%s",
+                user_id,
+                msg.chat.id,
+                album_id,
+            )
+            return
+        post_plan_albums.add(album_id)
+        log.info(
+            "[POST_PLAN_BTN] Handling new album user=%s chat=%s album=%s",
+            user_id,
+            msg.chat.id,
+            album_id,
+        )
+    else:
+        log.info(
+            "[POST_PLAN_BTN] Handling single media message user=%s chat=%s msg=%s",
+            user_id,
+            msg.chat.id,
+            msg.message_id,
+        )
 
     kb = InlineKeyboardMarkup(
         inline_keyboard=[


### PR DESCRIPTION
## Summary
- Track `media_group_id` values for post-plan messages
- Skip sending a planning button on duplicate album messages
- Add info logging for album handling diagnostics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895df6b8ffc832ab22af1e8827fa63d