### PR TITLE
feat: add group debug handlers

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -1000,27 +1000,38 @@ async def _unused_cmd_history_3(msg: Message):
             print(f"Ошибка при отправке истории: {e}")
 
 # ==============================
-# POSTING GROUP — новая версия
+#  POSTING GROUP — обновлённая версия
+# ==============================
+
+# DEBUG: вывести в лог ID постинг-группы при старте
+log.info(f"[DEBUG] POST_PLAN_GROUP_ID={POST_PLAN_GROUP_ID} (type={type(POST_PLAN_GROUP_ID)})")
+
+# ==============================
+# DEBUG: универсальный хендлер для любых сообщений в группе
+# ==============================
+@dp.message()
+async def debug_all_msgs(msg: Message):
+    if msg.chat.id == POST_PLAN_GROUP_ID:
+        log.info(f"[DEBUG GROUP MSG] chat={msg.chat.id}, user={msg.from_user.id}, type={msg.content_type}, media_group_id={msg.media_group_id}")
+    # не мешаем другим хендлерам
+
+
+# 1. Хендлер для добавления кнопки Post Plan
 # ==============================
 
 @dp.message(F.chat.id == POST_PLAN_GROUP_ID)
 async def add_post_plan_button(msg: Message):
     """Добавляет кнопку 📆 Post Plan под каждым одиночным медиа в постинг-группе"""
-    log.info(f"[POST_PLAN] Получено сообщение {msg.message_id} от {msg.from_user.id} в {msg.chat.id}")
+    log.info(f"[POST_PLAN] Получено сообщение {msg.message_id} от {msg.from_user.id} в {msg.chat.id} ({msg.content_type})")
 
     # Проверка: только админы
     if msg.from_user.id not in ADMINS:
         log.info(f"[POST_PLAN] Игнор: не админ ({msg.from_user.id})")
         return
 
-    # Пропускаем альбомы
-    if msg.media_group_id:
-        log.info(f"[POST_PLAN] Игнор: альбом media_group_id={msg.media_group_id}")
-        return
-
-    # Только одиночные медиа (фото, видео, gif-анимация)
+    # Разрешаем фото, видео, анимацию, а также первый элемент альбома — для теста
     if not (msg.photo or msg.video or msg.animation):
-        log.info(f"[POST_PLAN] Игнор: не медиа ({msg.message_id})")
+        log.info(f"[POST_PLAN] Игнор: не медиа ({msg.message_id}, {msg.content_type})")
         return
 
     kb = InlineKeyboardMarkup(


### PR DESCRIPTION
## Summary
- log posting group chat ID on startup for easier debugging
- add a generic message logger for all group messages
- enrich Post Plan handler logging and allow first album item

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68961754fc64832abc8429bb97889b77