### PR TITLE
Preserve FSM data during post plan transitions

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -1076,7 +1076,8 @@ async def start_post_plan(cq: CallbackQuery, state: FSMContext):
 @dp.callback_query(F.data.startswith("post_to:"), Post.wait_channel)
 async def post_choose_channel(cq: CallbackQuery, state: FSMContext):
     channel = cq.data.split(":")[1]
-    await state.update_data(channel=channel, media_ids=[], text="")
+    # Только обновляем выбранный канал, не сбрасывая другие данные
+    await state.update_data(channel=channel)
     await state.set_state(Post.wait_content)
     kb = InlineKeyboardBuilder()
     kb.button(text="Готово", callback_data="post_done")
@@ -1095,7 +1096,6 @@ async def post_content(msg: Message, state: FSMContext):
     if not channel:
         log.error("[POST_PLAN] Ошибка: канал не выбран")
         await msg.reply("Ошибка: не выбран канал.")
-        await state.clear()
         return
 
     if msg.photo or msg.video or msg.animation:


### PR DESCRIPTION
## Summary
- Avoid clearing FSM when selecting a channel during post planning
- Skip premature FSM reset when content arrives without channel

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68967529a6f0832aa8e9f6341297f5f2