### PR TITLE
Preserve source message ID in channel selection

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -1087,8 +1087,8 @@ async def start_post_plan(cq: CallbackQuery, state: FSMContext):
 @dp.callback_query(F.data.startswith("post_to:"), Post.wait_channel)
 async def post_choose_channel(cq: CallbackQuery, state: FSMContext):
     channel = cq.data.split(":")[1]
-    # Сохраняем выбранный канал и ID исходного сообщения
-    await state.update_data(channel=channel, source_message_id=cq.message.message_id)
+    # Сохраняем выбранный канал (ID исходного сообщения уже сохранён)
+    await state.update_data(channel=channel)
     await state.set_state(Post.wait_content)
     kb = InlineKeyboardMarkup(
         inline_keyboard=[[InlineKeyboardButton(text="✅ Готово", callback_data="post_done")]]


### PR DESCRIPTION
## Summary
- Keep existing `source_message_id` when choosing a post channel

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897750f1a40832ab869ba530e95ab6d