### PR TITLE
Add logging for 'Done' button creation

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -1094,6 +1094,7 @@ async def post_choose_channel(cq: CallbackQuery, state: FSMContext):
         inline_keyboard=[[InlineKeyboardButton(text="✅ Готово", callback_data="post_done")]]
     )
     await cq.message.edit_text("Пришли текст поста или медиа.", reply_markup=kb)
+    log.info(f"[POST_PLAN] Кнопка 'Готово' создана для message_id={cq.message.message_id}")
     log.info(f"[POST_PLAN] Выбран канал: {channel}")
 
 


### PR DESCRIPTION
## Summary
- log when 'Done' button is created in post_choose_channel

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689775298b38832a908f6cb410be8566