### PR TITLE
chore: use persistent sqlite path

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -6,7 +6,6 @@
 # • RU/EN/ES UI           → auto by language_code
 
 import os, logging, httpx, time, aiosqlite, traceback, sqlite3
-from pathlib import Path
 import asyncio
 import aiohttp
 from os import getenv
@@ -14,8 +13,8 @@ from aiogram import Bot
 from aiogram.client.session.aiohttp import AiohttpSession
 from datetime import datetime
 from types import SimpleNamespace
-os.makedirs("data", exist_ok=True)
-DB_PATH = Path(__file__).parent / "data" / "messages.db"
+os.makedirs("/app/data", exist_ok=True)
+DB_PATH = "/app/data/juicyfox.db"
 
 if not os.path.exists(DB_PATH):
     with sqlite3.connect(DB_PATH) as db:


### PR DESCRIPTION
## Summary
- store SQLite database in `/app/data/juicyfox.db`
- ensure persistent directory exists on startup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6897de12ccf0832a823463c82993a344