### PR TITLE
Fix price key initialization in posting FSM

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -76,6 +76,8 @@ class Post(StatesGroup):
     wait_channel = State()
     select_datetime = State()
     select_stars = State()
+    wait_description = State()
+    wait_price = State()
     wait_content = State()
     wait_confirm = State()
 
@@ -239,6 +241,11 @@ CHANNEL_TARIFFS = {
     "vip": "Подписка 35 $",
     "luxury": "Подписка 15 $",
 }
+
+PAID_CHANNELS = {"vip", "luxury"}
+
+def is_paid_channel(channel: str) -> bool:
+    return channel in PAID_CHANNELS
 
 log.info(
     "Env CHAT_GROUP_ID=%s HISTORY_GROUP_ID=%s LIFE_CHANNEL_ID=%s POST_PLAN_GROUP_ID=%s",
@@ -498,6 +505,7 @@ L10N={
 'dt_prompt':'Выберите дату и время','dt_ok':'✅ Подтвердить','dt_cancel':'❌ Отмена',
 'ask_stars':'Укажи количество Stars:',
 'ask_content':'Пришли текст поста или медиа.',
+'set_price_prompt':'Укажи цену поста:',
 'free_label':'FREE',
 'done_label':'✅ Готово',
 },
@@ -552,6 +560,7 @@ Just you and me... Let’s get a little closer 💋
 'dt_prompt':'Choose date & time','dt_ok':'✅ Confirm','dt_cancel':'❌ Cancel',
 'ask_stars':'Specify the number of Stars:',
 'ask_content':'Send the post text or media.',
+'set_price_prompt':'Set the post price:',
 'free_label':'FREE',
 'done_label':'✅ Done',
   "vip_secret_desc": "Your personal access to Juicy Fox’s VIP Secret 😈\n🔥 Everything you've been fantasizing about:\n📸 More HD Photo close-up nudes 🙈\n🎥 Videos where I play with my pussy 💦\n💬 Juicy Chat — where I reply to you personally, with video-rols 😘\n📆 Duration: 30 days\n💸 Price: $35\n💳💵💱 — choose your preferred payment method"
@@ -607,6 +616,7 @@ Solo tú y yo... Acércate un poquito más 💋
 'dt_prompt':'Elige fecha y hora','dt_ok':'✅ Confirmar','dt_cancel':'❌ Cancelar',
 'ask_stars':'Indica la cantidad de Stars:',
 'ask_content':'Envía el texto o media del post.',
+'set_price_prompt':'Indica el precio del post:',
 'free_label':'FREE',
 'done_label':'✅ Listo',
   }
@@ -1306,6 +1316,27 @@ async def stars_selected(cq: CallbackQuery, state: FSMContext):
     await state.set_state(Post.wait_content)
     log.info("[POST_PLAN] Transition to Post.wait_content")
     await cq.message.edit_text(tr(lang, 'ask_content'), reply_markup=done_kb(lang))
+
+@dp.message(Post.wait_description, F.chat.id == POST_PLAN_GROUP_ID)
+async def post_description(msg: Message, state: FSMContext):
+    lang = msg.from_user.language_code
+    desc = msg.text or ''
+    await state.update_data(description=desc)
+    data = await state.get_data()
+    if is_paid_channel(data.get('channel')):
+        await state.update_data(price=None)
+        await state.set_state(Post.wait_price)
+        await msg.answer(tr(lang, 'set_price_prompt'))
+    else:
+        await state.set_state(Post.wait_content)
+        await msg.answer(tr(lang, 'ask_content'), reply_markup=done_kb(lang))
+
+@dp.message(Post.wait_price, F.chat.id == POST_PLAN_GROUP_ID)
+async def post_price(msg: Message, state: FSMContext):
+    lang = msg.from_user.language_code
+    await state.update_data(price=msg.text)
+    await state.set_state(Post.wait_content)
+    await msg.answer(tr(lang, 'ask_content'), reply_markup=done_kb(lang))
 
 @dp.message(Post.wait_content, F.chat.id == POST_PLAN_GROUP_ID)
 async def post_content(msg: Message, state: FSMContext):


### PR DESCRIPTION
## Summary
- initialize price field before moving from description to price step in posting flow
- add multi-language prompt for setting post price
- add helper to detect paid channels

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a82e54610832aa3aa27f75a21c642