### PR TITLE
Clear webhook before starting polling

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -1739,6 +1739,8 @@ async def main():
     allowed_updates = dp.resolve_used_update_types()
     if "callback_query" not in allowed_updates:
         allowed_updates.append("callback_query")
+    await bot.delete_webhook(drop_pending_updates=True)
+    logging.info("Webhook cleared before starting polling")
     await dp.start_polling(bot, allowed_updates=allowed_updates)
 
 @dp.message(Command("test_vip"))


### PR DESCRIPTION
## Summary
- clear webhook with drop pending updates before polling

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c60dfccd0832ab622c2500d045590