### PR TITLE
Log allowed updates before polling

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -1739,6 +1739,7 @@ async def main():
     allowed_updates = dp.resolve_used_update_types()
     if "callback_query" not in allowed_updates:
         allowed_updates.append("callback_query")
+    logging.info(f"Allowed updates: {allowed_updates}")
     await dp.start_polling(bot, allowed_updates=allowed_updates)
 
 @dp.message(Command("test_vip"))


### PR DESCRIPTION
## Summary
- Log allowed update types before the dispatcher starts polling

## Testing
- `python -m py_compile juicyfox_bot_single.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c60e1803c832a83dd347939cf4384