### PR TITLE
Use Redis-based FSM storage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ requests>=2.31,<3.0
 pipdeptree
 httpx
 aiosqlite
+redis>=5.0,<6.0
 gunicorn
 fastapi
 uvicorn[standard]


### PR DESCRIPTION
## Summary
- Replace in-memory FSM storage with Redis storage
- Configure Redis connection via environment variables
- Add redis library to requirements

## Testing
- `python -m py_compile juicyfox_bot_single.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c77991d54832a9c5e7330b28e6a8c