### PR TITLE
Add Prometheus metrics

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,8 +1,9 @@
 from fastapi import FastAPI
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 import asyncio
 from juicyfox_bot_single import main as run_bot
 from .check_logs import get_logs_clean, get_logs_full
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
 app = FastAPI(default_response_class=JSONResponse)
 
@@ -13,6 +14,11 @@ async def full_logs():
 @app.get("/logs/clean")
 async def clean_logs():
     return await get_logs_clean()
+
+@app.get("/metrics")
+async def metrics() -> Response:
+    """Expose Prometheus metrics."""
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
 
 @app.on_event("startup")
 async def startup_event():

--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,19 @@
+from prometheus_client import Counter, Gauge, Histogram
+
+# Histogram for measuring the end-to-end latency of posting events
+posting_latency_seconds = Histogram(
+    "posting_latency_seconds",
+    "End-to-end posting latency in seconds",
+)
+
+# Gauge representing the number of events pending in the posting queue
+posting_queue_depth = Gauge(
+    "posting_queue_depth",
+    "Number of events waiting to be processed",
+)
+
+# Counter tracking the number of send errors that occurred
+posting_send_errors_total = Counter(
+    "posting_send_errors_total",
+    "Total count of errors while sending postings",
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ aiosqlite
 gunicorn
 fastapi
 uvicorn[standard]
+prometheus-client

--- a/worker_posting.py
+++ b/worker_posting.py
@@ -1,0 +1,42 @@
+import time
+from typing import Any, Awaitable, Callable
+
+from metrics import (
+    posting_latency_seconds,
+    posting_queue_depth,
+    posting_send_errors_total,
+)
+
+
+async def worker_posting(
+    queue,
+    send_fn: Callable[[Any], Awaitable[None]],
+) -> None:
+    """Consume events from ``queue`` and send them using ``send_fn``.
+
+    Metrics are recorded for queue depth, latency and send errors.
+    Each event is expected to optionally contain ``enqueue_ts`` – the
+    UNIX timestamp when it was queued. If missing, the current time is
+    used instead, making the latency measurement best effort.
+    """
+    while True:
+        event = await queue.get()
+        posting_queue_depth.set(queue.qsize())
+
+        # Determine when the event was enqueued
+        enqueue_ts = None
+        if isinstance(event, dict):
+            enqueue_ts = event.get("enqueue_ts")
+        if enqueue_ts is None:
+            enqueue_ts = getattr(event, "enqueue_ts", None)
+        if enqueue_ts is None:
+            enqueue_ts = time.time()
+
+        try:
+            await send_fn(event)
+            posting_latency_seconds.observe(time.time() - enqueue_ts)
+        except Exception:
+            posting_send_errors_total.inc()
+        finally:
+            queue.task_done()
+            posting_queue_depth.set(queue.qsize())


### PR DESCRIPTION
## Summary
- expose Prometheus metrics from API
- track posting queue depth, latency and errors

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c77a0f6d0832aa30445ab9ab04791