### PR TITLE
Fix startup hook signature

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -281,7 +281,7 @@ if not TELEGRAM_TOKEN or not CRYPTOBOT_TOKEN:
     raise RuntimeError('Set TELEGRAM_TOKEN and CRYPTOBOT_TOKEN env vars')
 
 # --- Startup ------------------------------------------------
-async def on_startup():
+async def on_startup(bot: Bot):
     print("DEBUG: on_startup called")
     await _db_exec(
         "CREATE TABLE IF NOT EXISTS reply_links (reply_msg_id INTEGER PRIMARY KEY, user_id INTEGER)"


### PR DESCRIPTION
## Summary
- accept `Bot` argument in `on_startup` to align with aiogram startup lifecycle

## Testing
- `pytest -q`
- `python - <<'PY'
import asyncio, os
os.environ['TELEGRAM_TOKEN'] = '123:ABC'
os.environ['CRYPTOBOT_TOKEN'] = 'dummy'
from juicyfox_bot_single import dp, bot
async def test():
    try:
        await dp.emit_startup(bot)
        print('startup ok')
    except Exception as e:
        print('error', type(e).__name__, e)
asyncio.run(test())
PY`
- `docker build -t juicybot .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_689cf305f6d8832aa5047b81f2524549