### PR TITLE
Execute main when running script

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -1842,3 +1842,5 @@ async def delete_post_cmd(msg: Message):
     except Exception as e:
         print(f"❌ Ошибка удаления: {e}")
 
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- Ensure juicyfox_bot_single.py executes `main()` when run directly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689cfa333ec4832a88b88d50ffb4ef94