### PR TITLE
Configure webhook startup and add logging

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -34,6 +34,7 @@ async def startup_event():
     log.info("Starting bot from API startup event")
     await run_bot()
     log.info("Bot started from API startup event")
+    log.info("FastAPI application launched")
 
 
 @app.post("/bot/{bot_id}/webhook")

--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -1816,10 +1816,6 @@ async def main():
         return
     bot_pool[str(me.id)] = bot
     webhook_base = getenv("WEBHOOK_URL")
-    if not webhook_base:
-        log.warning("WEBHOOK_URL is empty. Starting polling mode")
-        await dp.start_polling(bot)
-        return
     allowed_updates = dp.resolve_used_update_types()
     if "callback_query" not in allowed_updates:
         allowed_updates.append("callback_query")
@@ -1828,6 +1824,7 @@ async def main():
         drop_pending_updates=True,
         allowed_updates=allowed_updates,
     )
+    log.info("Webhook installed at %s/bot/%s/webhook", webhook_base, me.id)
     await dp.emit_startup(bot)
 
     # aiohttp web‑server


### PR DESCRIPTION
## Summary
- Always set Telegram webhook from `WEBHOOK_URL` and emit startup immediately
- Log webhook installation and FastAPI application launch

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dad4dd3ac832abe85d09a5f0f4da4