### PR TITLE
docs: add webhook-only env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Bot operates exclusively in webhook mode; polling is unsupported.
+TELEGRAM_TOKEN=your_bot_token
+CRYPTOBOT_TOKEN=your_crypto_bot_token
+# URL that Telegram uses for delivering updates to this bot
+WEBHOOK_URL=https://yourdomain.northflank.app
+NORTHFLANK_API_TOKEN=your_token_here
+NORTHFLANK_PROJECT_ID=your_project_id
+NORTHFLANK_SERVICE_ID=your_service_id
+HISTORY_GROUP_ID=-1002721298286
+VIP_CHANNEL_ID=-1002756750911
+VIP_URL=https://t.me/+VKO7ggpmyHk1OTRl
+LIFE_CHANNEL_ID=-1002741506579
+LIFE_URL=https://t.me/JuisyFoxOfficialLife
+LUXURY_CHANNEL_ID=-1002808420871
+POST_PLAN_GROUP_ID=-1002825908735
+CHAT_GROUP_ID=-1002813332213
+LOG_CHANNEL_ID=-1002828644255


### PR DESCRIPTION
## Summary
- document webhook-only mode and add WEBHOOK_URL to example

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dbebd99c8832aa097376d052802e5