### PR TITLE
Remove outdated main router registration

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -1694,8 +1694,6 @@ async def scheduled_poster():
 # Routers are now registered in the FastAPI startup event
 
 # ---------------- Mount & run -----------------------------
-dp.include_router(main_r)
-log.info("main_r router included")
 dp.include_router(router)
 log.info("router included")
 dp.include_router(donate_r)


### PR DESCRIPTION
## Summary
- remove connection of non-existent `main_r` router and its logging to prevent NameError
- keep registration for all other routers

## Testing
- `pytest -q`
- `python -m py_compile juicyfox_bot_single.py`


------
https://chatgpt.com/codex/tasks/task_e_689dc57d80ac832a939d4bbebc4cb324