### PR TITLE
Remove undefined router registration

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -1694,8 +1694,7 @@ async def scheduled_poster():
 # Routers are now registered in the FastAPI startup event
 
 # ---------------- Mount & run -----------------------------
-dp.include_router(router)
-log.info("router included")
+# Removed obsolete generic router registration to prevent NameError
 dp.include_router(donate_r)
 log.info("donate_r router included")
 dp.include_router(router_pay)


### PR DESCRIPTION
## Summary
- fix startup crash by removing include of non-existent router
- keep module routers registered for scaling plan

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dca7bd350832a9461e8bc1873193a