### PR TITLE
feat: restore donate router stub

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -1695,6 +1695,14 @@ async def scheduled_poster():
 
 # ---------------- Mount & run -----------------------------
 # Removed obsolete generic router registration to prevent NameError
+from aiogram import Router
+donate_r = Router(name="donate")
+
+@donate_r.message()
+async def donate_stub(message):
+    # Заглушка логики донатов
+    await message.answer("💰 Донаты временно недоступны. Скоро появятся снова!")
+
 dp.include_router(donate_r)
 log.info("donate_r router included")
 dp.include_router(router_pay)


### PR DESCRIPTION
## Summary
- add donate router stub with placeholder handler
- prepare dispatcher for future donation integration

## Testing
- `python -m py_compile juicyfox_bot_single.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dcff487b4832aadb47c4313833601