### PR TITLE
Scope donate stub to /donate command

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -1698,7 +1698,7 @@ async def scheduled_poster():
 from aiogram import Router
 donate_r = Router(name="donate")
 
-@donate_r.message()
+@donate_r.message(Command("donate"))
 async def donate_stub(message):
     # Заглушка логики донатов
     await message.answer("💰 Донаты временно недоступны. Скоро появятся снова!")


### PR DESCRIPTION
## Summary
- limit donate placeholder router to only handle /donate command

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dd353800c832a8edd6881b671a84b