### PR TITLE
refactor: add local stubs for relay, history and ui routers

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -39,9 +39,29 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 from router_pay import router as router_pay
 from router_access import router as router_access
 from router_posting import router as router_posting
-from router_relay import router as router_relay
-from router_history import router as router_history
-from router_ui import router as router_ui
+
+router_relay = Router(name="relay")
+
+
+@router_relay.message(Command("relay_test"))
+async def relay_stub(message: Message):
+    await message.answer("🔄 Relay модуль временно недоступен.")
+
+
+router_history = Router(name="history")
+
+
+@router_history.message(Command("history_test"))
+async def history_stub(message: Message):
+    await message.answer("📜 История временно недоступна.")
+
+
+router_ui = Router(name="ui")
+
+
+@router_ui.message(Command("ui_test"))
+async def ui_stub(message: Message):
+    await message.answer("🖥️ UI модуль временно недоступен.")
 
 def get_post_plan_kb():
     kb = InlineKeyboardBuilder()


### PR DESCRIPTION
## Summary
- replace router_relay, router_history and router_ui imports with local Router stubs
- keep pay, access and posting routers registration unchanged

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ddd0bb164832a95264dc870e24130