### PR TITLE
Centralize router registration and remove donate stub

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -5,10 +5,6 @@ from juicyfox_bot_single import (
     main as run_bot,
     dp,
     bot_pool,
-    router_pay,
-    router_donate,
-    router_history,
-    router_ui,
 )
 import logging
 
@@ -35,17 +31,8 @@ async def metrics() -> Response:
 @app.on_event("startup")
 async def startup_event():
     log.info("Starting bot from API startup event")
-    for router, name in [
-        (router_pay, "router_pay"),
-        (router_donate, "router_donate"),
-        (router_history, "router_history"),
-        (router_ui, "router_ui"),
-    ]:
-        dp.include_router(router)
-        log.info("Registered %s", name)
     await run_bot()
     log.info("Bot started from API startup event")
-
     log.info("FastAPI server running")
 
 

--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -1711,20 +1711,9 @@ async def scheduled_poster():
                 )
 
 
-# Routers are now registered in the FastAPI startup event
-
 # ---------------- Mount & run -----------------------------
-# Removed obsolete generic router registration to prevent NameError
-from aiogram import Router
-donate_r = Router(name="donate")
-
-@donate_r.message(Command("donate"))
-async def donate_stub(message):
-    # Заглушка логики донатов
-    await message.answer("💰 Донаты временно недоступны. Скоро появятся снова!")
-
-dp.include_router(donate_r)
-log.info("donate_r router included")
+dp.include_router(router_donate)
+log.info("router_donate registered")
 dp.include_router(router_pay)
 log.info("router_pay registered")
 dp.include_router(router_access)


### PR DESCRIPTION
## Summary
- remove duplicate router includes from FastAPI app
- register all routers once in `juicyfox_bot_single.py` and enable real donate router

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689de55c28b0832ab4905cd72633af81