### PR TITLE
refactor: reuse relay router

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -41,8 +41,7 @@ from router_access import router as router_access
 from router_posting import router as router_posting
 from router_history import router as router_history
 from router_ui import router as router_ui
-
-router_relay = Router(name="relay")
+from router_relay import router as router_relay
 
 
 @router_relay.message(Command("relay_test"))


### PR DESCRIPTION
## Summary
- reuse imported relay router instead of creating a new empty one

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0a792f744832a90541967d940f203