### PR TITLE
Refactor UI handlers into dedicated router module

### DIFF
--- a/juicyfox_bot_single.py
+++ b/juicyfox_bot_single.py
@@ -937,37 +937,6 @@ async def tip_menu(cq: CallbackQuery):
     await cq.message.answer(tr(lang, 'choose_action'), reply_markup=kb.as_markup())
 
 
-@dp.message(lambda msg: msg.text == "SEE YOU MY CHAT💬")
-async def handle_chat_btn(msg: Message, state: FSMContext):
-    lang = msg.from_user.language_code
-    await state.set_state(ChatGift.plan)
-    await msg.answer(
-        tr(lang, 'chat_access'),
-        reply_markup=chat_plan_kb(lang)
-    )
-
-
-
-
-@dp.message(lambda msg: msg.text == "💎 Luxury Room – 15$")
-async def luxury_room_reply(msg: Message):
-    lang = msg.from_user.language_code
-    kb = InlineKeyboardBuilder()
-    for t, c in CURRENCIES:
-        kb.button(text=t, callback_data=f'payc:club:{c}')
-    kb.button(text="⬅️ Назад", callback_data="back")
-    kb.adjust(2)
-    await msg.answer(tr(lang, 'luxury_room_desc'), reply_markup=kb.as_markup())
-@dp.message(lambda msg: msg.text == "❤️‍🔥 VIP Secret – 35$")
-async def vip_secret_reply(msg: Message):
-    lang = msg.from_user.language_code
-    await msg.answer(
-        tr(lang, 'vip_secret_desc'),
-        reply_markup=vip_currency_kb()
-    )
-
-
-
 
 
 # ---------------- Relay private ↔ group -------------------

--- a/router_ui.py
+++ b/router_ui.py
@@ -1,3 +1,38 @@
 from aiogram import Router
+from aiogram.types import Message
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+from aiogram.fsm.context import FSMContext
+
 
 router = Router()
+
+
+@router.message(lambda msg: msg.text == "SEE YOU MY CHAT💬")
+async def handle_chat_btn(msg: Message, state: FSMContext):
+    lang = msg.from_user.language_code
+    await state.set_state(ChatGift.plan)
+    await msg.answer(
+        tr(lang, 'chat_access'),
+        reply_markup=chat_plan_kb(lang)
+    )
+
+
+@router.message(lambda msg: msg.text == "💎 Luxury Room – 15$")
+async def luxury_room_reply(msg: Message):
+    lang = msg.from_user.language_code
+    kb = InlineKeyboardBuilder()
+    for t, c in CURRENCIES:
+        kb.button(text=t, callback_data=f'payc:club:{c}')
+    kb.button(text="⬅️ Назад", callback_data="back")
+    kb.adjust(2)
+    await msg.answer(tr(lang, 'luxury_room_desc'), reply_markup=kb.as_markup())
+
+
+@router.message(lambda msg: msg.text == "❤️‍🔥 VIP Secret – 35$")
+async def vip_secret_reply(msg: Message):
+    lang = msg.from_user.language_code
+    await msg.answer(
+        tr(lang, 'vip_secret_desc'),
+        reply_markup=vip_currency_kb()
+    )
+


### PR DESCRIPTION
## Summary
- Implement handle_chat_btn, luxury_room_reply and vip_secret_reply in `router_ui.py`
- Remove legacy handler implementations from `juicyfox_bot_single.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0ccef5bec832a86d170f94c5270ae