### PR TITLE
Remove python-dotenv dependency

### DIFF
--- a/api/check_logs.py
+++ b/api/check_logs.py
@@ -1,9 +1,6 @@
 import os
 import httpx
-from dotenv import load_dotenv
 import aiofiles
-
-load_dotenv()
 
 NORTHFLANK_API_TOKEN = os.getenv("NORTHFLANK_API_TOKEN")
 NORTHFLANK_PROJECT_ID = os.getenv("NORTHFLANK_PROJECT_ID")

--- a/apps/bot_core/main.py
+++ b/apps/bot_core/main.py
@@ -1,7 +1,6 @@
 import os
 import asyncio
 import logging
-from dotenv import load_dotenv
 
 from aiogram import Bot, Dispatcher
 from fastapi import FastAPI
@@ -10,9 +9,6 @@ from modules.ui_membership.handlers import router as router_ui
 from router_pay import router as router_pay
 from router_posting import router as router_posting
 from router_relay import router as router_relay
-
-# Load environment variables from a local .env file if present
-load_dotenv()
 
 # Required environment variables
 TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 aiogram>=3.2.0,<3.3
 aiohttp==3.9.5
 pydantic>=2.4.1,<2.5.0
-python-dotenv>=1.0,<2.0
 requests>=2.31,<3.0
 pipdeptree
 httpx


### PR DESCRIPTION
## Summary
- avoid loading a local .env file so configuration is taken only from environment variables
- clean up unused python-dotenv imports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a23792d42c832abe0ee789e026b2a0