### PR TITLE
Add missing choose_tier state in ChatGift

### DIFF
--- a/modules/common/shared.py
+++ b/modules/common/shared.py
@@ -29,6 +29,7 @@ log = logging.getLogger(__name__)
 class ChatGift(StatesGroup):
     plan = State()
     access = State()
+    choose_tier = State()
 
 # ✅ Утилиты
 async def create_invoice(


### PR DESCRIPTION
## Summary
- expand ChatGift FSM with choose_tier state

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a46d39fe88832ab00beecec491a988