### PR TITLE
Add CryptoBot payment webhook endpoint

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -11,9 +11,11 @@ import logging
 log = logging.getLogger(__name__)
 
 from .check_logs import get_logs_clean, get_logs_full
+from .payments import router as payments_router
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
 app = FastAPI(default_response_class=JSONResponse)
+app.include_router(payments_router)
 
 @app.get("/logs")
 async def full_logs():

--- a/api/payments.py
+++ b/api/payments.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter, Request
+from modules.payments import normalize_webhook
+import logging
+
+log = logging.getLogger("juicyfox.api.payments")
+
+router = APIRouter()
+
+
+@router.post("/payments/cryptobot")
+async def cryptobot_webhook(request: Request):
+    payload = await request.json()
+    norm = normalize_webhook(payload)
+    log.info("payment webhook received: %s", norm)
+    # TODO: здесь можно будет обновить доступ пользователя по norm["meta"]
+    return {"ok": True}


### PR DESCRIPTION
## Summary
- add `/payments/cryptobot` FastAPI endpoint to accept and log CryptoBot webhooks
- normalize webhook payload via `normalize_webhook`
- hook payments router into main app

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a848077448832a825bc04887a977b9