### PR TITLE
refactor: switch reply menu to new localization keys

### DIFF
--- a/modules/ui_membership/keyboards.py
+++ b/modules/ui_membership/keyboards.py
@@ -62,9 +62,9 @@ def reply_menu(lang: str) -> ReplyKeyboardMarkup:
     Лёгкое reply-меню на старый манер (тексты — из локалей).
     Можно показывать всегда — это не ломает inline-сценарии.
     """
-    chat_label = tr(lang, "btn_see_chat")
-    luxury_label = tr(lang, "btn_luxury")
-    vip_label = tr(lang, "btn_vip")
+    chat_label = tr(lang, "reply_chat_btn")
+    luxury_label = tr(lang, "reply_luxury_btn")
+    vip_label = tr(lang, "reply_vip_btn")
 
     return ReplyKeyboardMarkup(
         keyboard=[


### PR DESCRIPTION
## Summary
- switch reply menu buttons to new localization keys

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1a2d653f0832aa33f58cceb3850a5