### PR TITLE
chore: unify button keys

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -71,8 +71,6 @@
   "sent_to_vip": "✅ Successfully sent to VIP channel",
   "admin_delete_only": "⛔️ Only admin can delete posts.",
   "delete_usage": "❌ Use /delete_post <id>",
-  "start_message": "Welcome to JuicyFox 🦊",
+  "start_message": "Welcome to JuicyFox 🦊"
 
-  "reply_chat_btn": "💬 Juicy Chat",
-  "reply_vip_btn": "❤️‍🔥 VIP Secret - 35 $"
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -71,8 +71,6 @@
   "sent_to_vip": "✅ Enviado correctamente al canal VIP",
   "admin_delete_only": "⛔️ Solo el admin puede eliminar publicaciones.",
   "delete_usage": "❌ Usa /delete_post <id>",
-  "start_message": "Bienvenido a JuicyFox 🦊",
+  "start_message": "Bienvenido a JuicyFox 🦊"
 
-  "reply_chat_btn": "💬 Juicy Chat",
-  "reply_vip_btn": "❤️‍🔥 VIP Secret - 35 $"
 }

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -72,8 +72,6 @@
   "sent_to_vip": "✅ Успешно отправлено в VIP-канал",
   "admin_delete_only": "⛔️ Только админ может удалять посты.",
   "delete_usage": "❌ Используй /delete_post <id>",
-  "start_message": "Добро пожаловать в JuicyFox 🦊",
+  "start_message": "Добро пожаловать в JuicyFox 🦊"
 
-  "reply_chat_btn": "💬 Juicy Chat",
-  "reply_vip_btn": "❤️‍🔥 VIP Secret - 35 $"
 }

--- a/modules/common/i18n.py
+++ b/modules/common/i18n.py
@@ -13,7 +13,7 @@ for lang in ("ru", "en", "es"):
 BUTTONS = {
     "btn_life": "👀 Juicy Life — Free",
     "btn_club": "💎 Luxury Room - 15 $",
-    "btn_vip": "❤️‍🔥 VIP Secret — 35$",
+    "btn_vip": "❤️‍🔥 VIP Secret - 35 $",
     "btn_chat": "💬 Juicy Chat",
     "btn_donate": "🎁 Custom",
     "btn_see_chat": "SEE YOU MY CHAT💬",

--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -208,7 +208,7 @@ def _norm(s: Optional[str]) -> str:
     return (s or "").strip()
 
 @router.message(lambda m: _norm(m.text) in {
-    _norm(tr(get_lang(m.from_user), "reply_chat_btn")) or "SEE YOU MY CHAT💬"
+    _norm(tr(get_lang(m.from_user), "btn_chat")) or "SEE YOU MY CHAT💬"
 })
 async def legacy_reply_chat(msg: Message, state: FSMContext) -> None:
     await state.clear()
@@ -227,7 +227,7 @@ async def legacy_reply_luxury(msg: Message) -> None:
     await msg.answer(tr(lang, "luxury_room_desc"), reply_markup=kb.as_markup())
 
 @router.message(lambda m: _norm(m.text) in {
-    _norm(tr(get_lang(m.from_user), "reply_vip_btn")) or "❤️‍🔥 VIP Secret – 35$"
+    _norm(tr(get_lang(m.from_user), "btn_vip")) or "❤️‍🔥 VIP Secret - 35 $"
 })
 async def legacy_reply_vip(msg: Message) -> None:
     lang = get_lang(msg.from_user)
@@ -310,7 +310,7 @@ async def luxury_room_reply(msg: Message):
     await msg.answer(tr(lang, "luxury_room_desc"), reply_markup=kb.as_markup())
 
 
-@router.message(F.text == "❤️‍🔥 VIP Secret – 35$")
+@router.message(F.text == "❤️‍🔥 VIP Secret - 35 $")
 async def vip_secret_reply(msg: Message):
     lang = get_lang(msg.from_user)
     await msg.answer(tr(lang, "vip_secret_desc"), reply_markup=vip_currency_kb())

--- a/modules/ui_membership/keyboards.py
+++ b/modules/ui_membership/keyboards.py
@@ -62,9 +62,9 @@ def reply_menu(lang: str) -> ReplyKeyboardMarkup:
     Лёгкое reply-меню на старый манер (тексты — из локалей).
     Можно показывать всегда — это не ломает inline-сценарии.
     """
-    chat_label = tr(lang, "reply_chat_btn")
+    chat_label = tr(lang, "btn_chat")
     luxury_label = tr(lang, "btn_club")
-    vip_label = tr(lang, "reply_vip_btn")
+    vip_label = tr(lang, "btn_vip")
 
     return ReplyKeyboardMarkup(
         keyboard=[


### PR DESCRIPTION
## Summary
- replace deprecated reply_* button keys with btn_* equivalents
- normalize button texts in i18n fallback dictionary
- remove obsolete reply_* keys from locales

## Testing
- `python -m py_compile modules/common/i18n.py modules/ui_membership/handlers.py modules/ui_membership/keyboards.py`
- `python -m json.tool locales/en.json > /dev/null`
- `python -m json.tool locales/ru.json > /dev/null`
- `python -m json.tool locales/es.json > /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_68b1b714a188832a93b7f85aba4074db