### PR TITLE
Reset state in start handler

### DIFF
--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -51,7 +51,8 @@ class Donate(StatesGroup):
 # /start и главное меню
 # =======================
 @router.message(Command("start"))
-async def cmd_start(message: Message) -> None:
+async def cmd_start(message: Message, state: FSMContext) -> None:
+    await state.clear()
     lang = get_lang(message.from_user)
     if START_PHOTO.exists():
         photo = FSInputFile(START_PHOTO)


### PR DESCRIPTION
## Summary
- Clear FSM state when handling /start command to reset user state

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2c1310454832aac4b923aba8dfc9f