### PR TITLE
Handle webhook URL in startup

### DIFF
--- a/apps/bot_core/main.py
+++ b/apps/bot_core/main.py
@@ -78,4 +78,7 @@ async def on_startup():
     await init_db()
     url = WEBHOOK_URL or (f"{BASE_URL}/bot/{BOT_ID}/webhook" if BASE_URL else None)
     if not url:
-        log
+        log.warning("WEBHOOK_URL/BASE_URL not set; webhook skipped")
+        return
+    await bot.set_webhook(url)
+    log.info("Webhook set to %s", url)


### PR DESCRIPTION
## Summary
- warn and skip webhook if WEBHOOK_URL/BASE_URL not set
- set webhook and log when URL present

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2c2112910832a9ee699733f35a81a