### PR TITLE
fix: correct BASE_DIR for start image

### DIFF
--- a/modules/constants/paths.py
+++ b/modules/constants/paths.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
-BASE_DIR = Path(__file__).resolve().parents[1]  # корень проекта
+# Путь до корня проекта
+BASE_DIR = Path(__file__).resolve().parents[2]
 DATA_DIR = BASE_DIR / "data"
 
 START_PHOTO = DATA_DIR / "start.jpg"


### PR DESCRIPTION
## Summary
- fix BASE_DIR to point to project root and define START_PHOTO accordingly

## Testing
- `python - <<'PY'
from modules.constants.paths import START_PHOTO, BASE_DIR
print('BASE_DIR', BASE_DIR)
print('START_PHOTO', START_PHOTO, START_PHOTO.exists())
PY`
- `python - <<'PY'
from modules.constants.paths import START_PHOTO
from aiogram.types import FSInputFile
photo = FSInputFile(START_PHOTO) if START_PHOTO.exists() else "https://files.catbox.moe/cqckle.jpg"
print(type(photo).__name__, getattr(photo, 'path', None))
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2cce6377c832ab8e3b92adaa4bd7e