### PR TITLE
Fix payments webhook route path

### DIFF
--- a/api/payments.py
+++ b/api/payments.py
@@ -7,7 +7,7 @@ import logging
 log = logging.getLogger("juicyfox.api.payments")
 router = APIRouter()
 
-@router.post("/payments/cryptobot")
+@router.post("/cryptobot")
 async def cryptobot_webhook(request: Request):
     # 1) безопасно читаем JSON
     try:


### PR DESCRIPTION
## Summary
- expose cryptobot payment webhook at `/cryptobot`
- keep payments router mounted under `/payments`

## Testing
- `pytest -q`
- `uvicorn api.main:app --port 8000 --host 0.0.0.0` then `curl -s -X POST -H 'Content-Type: application/json' -d '{}' http://localhost:8000/payments/cryptobot`


------
https://chatgpt.com/codex/tasks/task_e_68b2d8a4fc7c832a83a72530f7bc4897