### PR TITLE
Remove duplicate healthz handler from main API

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -14,6 +14,3 @@ app.include_router(payments_router, prefix="/payments")
 app.include_router(health_router)
 app.include_router(logs_router)
 
-@app.get("/healthz")
-def healthz():
-    return {"status": "ok"}


### PR DESCRIPTION
## Summary
- remove local /healthz handler in main API module, rely on health router

## Testing
- `python - <<'PY'
from api.main import app
from fastapi.testclient import TestClient
client = TestClient(app)
resp = client.get('/healthz')
print('status', resp.status_code)
print('body', resp.json())
PY`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b2dc3cd0f4832a86324c1ca42b9486