### PR TITLE
Add structured logging for webhook errors

### DIFF
--- a/api/webhook.py
+++ b/api/webhook.py
@@ -1,7 +1,10 @@
+import logging
+
 from fastapi import APIRouter, Request, Response, status
 from aiogram.types import Update
 
 router = APIRouter()
+log = logging.getLogger("juicyfox.api.webhook")
 
 @router.post("/webhook")
 async def telegram_webhook(request: Request) -> Response:
@@ -31,7 +34,7 @@ async def telegram_webhook(request: Request) -> Response:
         # Лучше проглотить и вернуть 200/204, а в своих логах посмотреть причину.
         try:
             # Минимальная попытка журналирования в stdout/stderr
-            print(f"[webhook] error: {e}")
+            log.exception("webhook error: %s", e)
         except Exception:
             pass
         return Response(status_code=status.HTTP_200_OK)


### PR DESCRIPTION
## Summary
- use module logger in `api/webhook.py`
- log webhook exceptions instead of printing

## Testing
- `pytest -q`
- `python - <<'PY'
import logging, asyncio
from api.webhook import telegram_webhook

logging.basicConfig(level=logging.ERROR)
class BadRequest:
    async def json(self):
        raise ValueError('boom')

response = asyncio.run(telegram_webhook(BadRequest()))
print('status', response.status_code)
PY`
- `python -m py_compile api/webhook.py`


------
https://chatgpt.com/codex/tasks/task_e_68b2de7603e8832aa2e25c6772644c93