### PR TITLE
feat: allow overriding port via env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,4 +44,4 @@ USER appuser
 EXPOSE 8080
 
 # по умолчанию запускаем FastAPI; берём PORT из окружения (fallback 8080)
-CMD ["uvicorn", "apps.bot_core.main:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["sh", "-c", "uvicorn apps.bot_core.main:app --host 0.0.0.0 --port ${PORT}"]


### PR DESCRIPTION
## Summary
- run uvicorn via shell to respect PORT env var

## Testing
- `pytest`
- `docker build -t port-test .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e00cf334832ab71ee40e048a5591