### PR TITLE
Use tuples for currency constants

### DIFF
--- a/modules/constants/currencies.py
+++ b/modules/constants/currencies.py
@@ -2,11 +2,21 @@
 
 """
 Список поддерживаемых валют для платежей.
-В монолите этот список был захардкожен, теперь вынесен в constants.
+Каждая запись содержит отображаемый заголовок и код валюты.
 """
 
 CURRENCIES = [
-    "USD", "EUR", "RUB", "UAH", "KZT",
-    "USDT", "BTC", "ETH", "BNB", "TRX",
-    "TON", "LTC", "DOGE"
+    ("USD", "USD"),
+    ("EUR", "EUR"),
+    ("RUB", "RUB"),
+    ("UAH", "UAH"),
+    ("KZT", "KZT"),
+    ("USDT", "USDT"),
+    ("BTC", "BTC"),
+    ("ETH", "ETH"),
+    ("BNB", "BNB"),
+    ("TRX", "TRX"),
+    ("TON", "TON"),
+    ("LTC", "LTC"),
+    ("DOGE", "DOGE"),
 ]

--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -37,7 +37,7 @@ VIP_PRICE_USD = float(os.getenv("VIP_30D_USD", "25"))
 CHAT_PRICE_USD = float(os.getenv("CHAT_30D_USD", "15"))
 
 # Удобный набор кодов валют: {"USD","EUR",...}
-CURRENCY_CODES = {code.upper() for code in CURRENCIES}
+CURRENCY_CODES = {code.upper() for _, code in CURRENCIES}
 
 
 # --- FSM для донатов (оставляем в UI-модуле) ---
@@ -227,8 +227,8 @@ async def legacy_reply_chat(msg: Message, state: FSMContext) -> None:
 async def legacy_reply_luxury(msg: Message) -> None:
     lang = get_lang(msg.from_user)
     kb = InlineKeyboardBuilder()
-    for code in CURRENCIES:
-        kb.button(text=code, callback_data="pay:chat")  # при желании сделай отдельный plan_code
+    for title, code in CURRENCIES:
+        kb.button(text=title, callback_data="pay:chat")  # при желании сделай отдельный plan_code
     kb.adjust(2)
     await msg.answer(tr(lang, "luxury_room_desc"), reply_markup=kb.as_markup())
 
@@ -316,8 +316,8 @@ async def handle_chat_btn(msg: Message, state: FSMContext):
 async def luxury_room_reply(msg: Message):
     lang = get_lang(msg.from_user)
     kb = InlineKeyboardBuilder()
-    for code in CURRENCIES:
-        kb.button(text=code, callback_data=f"payc:club:{code}")
+    for title, code in CURRENCIES:
+        kb.button(text=title, callback_data=f"payc:club:{code}")
     kb.button(text="⬅️ Назад", callback_data="back")
     kb.adjust(2)
     await msg.answer(tr(lang, "luxury_room_desc"), reply_markup=kb.as_markup())


### PR DESCRIPTION
## Summary
- represent each currency as a `(label, code)` tuple
- update membership handlers to unpack currency title and code

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b333c58a30832aa82200b4689d50cd