### PR TITLE
feat: add VIP currency selection

### DIFF
--- a/modules/ui_membership/keyboards.py
+++ b/modules/ui_membership/keyboards.py
@@ -22,12 +22,13 @@ def main_menu_kb(lang: str) -> InlineKeyboardMarkup:
 
 
 def vip_currency_kb(lang: str | None = None) -> InlineKeyboardMarkup:
-    """Экран VIP: даём кнопку оплаты (pay:vip) и Назад."""
-    b = InlineKeyboardBuilder()
-    b.button(text=tr(lang or "en", "btn_pay_vip"), callback_data="pay:vip")
-    b.button(text=tr(lang or "en", "btn_back"), callback_data="ui:back")
-    b.adjust(1)
-    return b.as_markup()
+    """Выбор валюты для оплаты VIP: vipay:<CODE> + Назад."""
+    kb = InlineKeyboardBuilder()
+    for code in CURRENCIES:
+        kb.button(text=code, callback_data=f"vipay:{code}")
+    kb.button(text="⬅️ Назад", callback_data="ui:back")
+    kb.adjust(2)
+    return kb.as_markup()
 
 
 def chat_plan_kb(lang: str | None = None) -> InlineKeyboardMarkup:


### PR DESCRIPTION
## Summary
- build VIP currency keyboard with per-currency vipay callbacks and back button

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b334f0df34832a93fe25680b077999