### PR TITLE
Add currency support for invoice creation

### DIFF
--- a/modules/payments/__init__.py
+++ b/modules/payments/__init__.py
@@ -26,6 +26,7 @@ class InvoiceRequest(TypedDict, total=False):
     plan_code: str
     amount_usd: float
     meta: Dict[str, Any]
+    currency: str
 
 
 class ProviderError(Exception):

--- a/modules/payments/providers/__init__.py
+++ b/modules/payments/providers/__init__.py
@@ -10,7 +10,9 @@ PAYMENT_PROVIDER = os.getenv("PAYMENT_PROVIDER", "cryptobot").lower()
 
 
 class PaymentsProvider(Protocol):
-    async def create_invoice(self, amount_usd: float, title: str, meta: Dict[str, Any]) -> InvoiceResponse: ...
+    async def create_invoice(
+        self, amount_usd: float, title: str, meta: Dict[str, Any], currency: str = "USD"
+    ) -> InvoiceResponse: ...
     def normalize_webhook(self, payload: Dict[str, Any]) -> Dict[str, Any]: ...
 
 

--- a/modules/payments/providers/cryptobot.py
+++ b/modules/payments/providers/cryptobot.py
@@ -25,13 +25,15 @@ STATUS_MAP = {
 
 
 class CryptobotProvider:
-    async def create_invoice(self, amount_usd: float, title: str, meta: Dict[str, Any]) -> InvoiceResponse:
+    async def create_invoice(
+        self, amount_usd: float, title: str, meta: Dict[str, Any], currency: str = "USD"
+    ) -> InvoiceResponse:
         if not CRYPTOBOT_TOKEN:
             raise ProviderError("CRYPTOBOT_TOKEN is not set")
 
         payload = {
             "amount": f"{amount_usd:.2f}",
-            "currency": "USD",
+            "currency": currency.upper(),
             "description": title[:200],
             "payload": json.dumps(meta, ensure_ascii=False),
         }

--- a/modules/payments/service.py
+++ b/modules/payments/service.py
@@ -31,13 +31,14 @@ async def _cryptobot_create_invoice(
     amount_usd: float,
     title: str,
     meta: Dict[str, Any],
+    currency: str,
 ) -> InvoiceResponse:
     if not CRYPTOBOT_TOKEN:
         raise ProviderError("CRYPTOBOT_TOKEN is not set")
 
     payload = {
         "amount": f"{amount_usd:.2f}",
-        "currency": "USD",
+        "currency": currency.upper(),
         "description": title[:200],
         "payload": json.dumps(meta, ensure_ascii=False),
     }
@@ -73,16 +74,23 @@ async def create_invoice(
     plan_code: str,
     amount_usd: float,
     meta: Dict[str, Any],
+    currency: str = "USD",
 ) -> InvoiceResponse:
     """
     Создаёт счёт через выбранного провайдера (ENV PAYMENT_PROVIDER, по умолчанию cryptobot).
     Возвращает dict: {pay_url, provider, invoice_id}.
+    Параметр ``currency`` передаётся напрямую провайдеру (например, ``USD``).
     """
     title = f"{plan_code} for user {user_id}"
     merged_meta = {**meta, "user_id": user_id, "plan_code": plan_code}
 
     if PAYMENT_PROVIDER == "cryptobot":
-        inv = await _cryptobot_create_invoice(amount_usd=amount_usd, title=title, meta=merged_meta)
+        inv = await _cryptobot_create_invoice(
+            amount_usd=amount_usd,
+            title=title,
+            meta=merged_meta,
+            currency=currency,
+        )
     else:
         raise ProviderError(f"unknown PAYMENT_PROVIDER={PAYMENT_PROVIDER}")
 

--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -131,6 +131,7 @@ async def pay_vip(cq: CallbackQuery) -> None:
         plan_code="vip_30d",
         amount_usd=float(amount),
         meta=_build_meta(cq.from_user.id, "vip_30d", currency),
+        currency=currency,
     )
     url = _invoice_url(inv)
     await cq.message.answer(tr(lang, "invoice_created"), reply_markup=donate_back_kb(lang))
@@ -147,6 +148,7 @@ async def pay_chat(cq: CallbackQuery) -> None:
         plan_code="chat_30d",
         amount_usd=float(amount),
         meta=_build_meta(cq.from_user.id, "chat_30d", currency),
+        currency=currency,
     )
     url = _invoice_url(inv)
     await cq.message.answer(tr(lang, "invoice_created"), reply_markup=donate_back_kb(lang))
@@ -194,6 +196,7 @@ async def donate_make_invoice(msg: Message, state: FSMContext) -> None:
         plan_code="donation",
         amount_usd=amount_usd,
         meta={"user_id": msg.from_user.id, "currency": cur, "kind": "donate", "bot_id": BOT_ID},
+        currency=cur,
     )
     url = _invoice_url(inv)
     await msg.answer(tr(lang, "invoice_created"))
@@ -296,6 +299,7 @@ async def donate_finish(msg: Message, state: FSMContext):
         plan_code="donation",
         amount_usd=amount_usd,
         meta={"user_id": msg.from_user.id, "currency": cur, "kind": "donate", "bot_id": BOT_ID},
+        currency=cur,
     )
     url = _invoice_url(inv)
     if url:


### PR DESCRIPTION
## Summary
- allow Cryptobot invoices to specify currency
- propagate currency through create_invoice API and providers
- update membership handlers to pass selected currency

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b336ed461c832abfa847dc3c7bdf75