### PR TITLE
refactor: drop legacy payment helpers

### DIFF
--- a/modules/common/shared.py
+++ b/modules/common/shared.py
@@ -1,79 +1,22 @@
-
 import os
 import json
-import logging
-import httpx
 from aiogram.fsm.state import StatesGroup, State
 
-# Здесь будут все общие константы, классы и функции,
-# которые нужны и боту, и UI-модулям.
+"""Shared helpers used by bot and UI modules."""
 
-# ✅ Константы
-# Список валют используется клавиатурами и хендлерами, поэтому
-# каждая запись содержит отображаемый текст и код валюты.
-CURRENCIES = [
-    ("TON", "ton"),
-    ("BTC", "btc"),
-    ("USDT", "usdt"),
-    ("ETH", "eth"),
-]
+# Константы и платежи берём из обновлённых модулей
+from modules.constants.currencies import CURRENCIES
+from modules.payments import create_invoice
 
 # LIFE_URL теперь берётся из переменных окружения
 # (если не задано в ENV, используется дефолтная ссылка)
 LIFE_URL = os.getenv("LIFE_URL", "https://t.me/JuicyFoxOfficialLife")
-
-CRYPTOBOT_TOKEN = os.getenv("CRYPTOBOT_TOKEN", "")
-log = logging.getLogger(__name__)
 
 # ✅ FSM-класс
 class ChatGift(StatesGroup):
     plan = State()
     access = State()
     choose_tier = State()
-
-# ✅ Утилиты
-async def create_invoice(
-    user_id: int,
-    amount: int,
-    currency: str,
-    description: str,
-    pl: str | None = None,
-):
-    """Создание инвойса через CryptoBot API."""
-    if currency.lower() not in [code for _, code in CURRENCIES]:
-        log.error("Unsupported currency: %s", currency)
-        return None
-
-    if not CRYPTOBOT_TOKEN:
-        log.error("CRYPTOBOT_TOKEN is not set")
-        return None
-
-    payload_str = f"{user_id}:{pl}" if pl else str(user_id)
-    url = "https://pay.crypt.bot/api/createInvoice"
-
-    try:
-        async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                url,
-                headers={"Authorization": f"Bearer {CRYPTOBOT_TOKEN}"},
-                json={
-                    "asset": currency.upper(),
-                    "amount": amount,
-                    "description": description,
-                    "payload": payload_str,
-                },
-            )
-        data = await resp.json()
-    except Exception as e:
-        log.exception("CryptoBot request failed: %s", e)
-        return None
-
-    if not data.get("ok"):
-        log.error("CryptoBot error: %s", data)
-        return None
-
-    log.info("Invoice created for user %s: %s %s", user_id, amount, currency)
-    return data["result"]["pay_url"]
 
 # ✅ Функция перевода
 LOCALES = {}


### PR DESCRIPTION
## Summary
- rely on constants.CURRENCIES and payments.create_invoice
- drop deprecated invoice helper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b337ed5904832a881c210ffb30bf7e