### PR TITLE
feat: support asset-based invoices

### DIFF
--- a/modules/payments/__init__.py
+++ b/modules/payments/__init__.py
@@ -26,7 +26,7 @@ class InvoiceRequest(TypedDict, total=False):
     plan_code: str
     amount_usd: float
     meta: Dict[str, Any]
-    currency: str
+    asset: str
 
 
 class ProviderError(Exception):

--- a/modules/payments/providers/__init__.py
+++ b/modules/payments/providers/__init__.py
@@ -11,7 +11,7 @@ PAYMENT_PROVIDER = os.getenv("PAYMENT_PROVIDER", "cryptobot").lower()
 
 class PaymentsProvider(Protocol):
     async def create_invoice(
-        self, amount_usd: float, title: str, meta: Dict[str, Any], currency: str = "USD"
+        self, amount_usd: float, title: str, meta: Dict[str, Any], asset: str = "USD"
     ) -> InvoiceResponse: ...
     def normalize_webhook(self, payload: Dict[str, Any]) -> Dict[str, Any]: ...
 

--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -141,7 +141,7 @@ async def pay_vip(cq: CallbackQuery) -> None:
         plan_code="vip_30d",
         amount_usd=float(amount),
         meta=_build_meta(cq.from_user.id, "vip_30d", currency),
-        currency=currency,
+        asset=currency,
     )
     url = _invoice_url(inv)
     await cq.message.answer(tr(lang, "invoice_created"), reply_markup=vip_currency_kb(lang))
@@ -164,6 +164,7 @@ async def vipay_currency(cq: CallbackQuery) -> None:
         plan_code="vip_30d",
         amount_usd=float(VIP_PRICE_USD),
         meta=_build_meta(cq.from_user.id, "vip_30d", cur),
+        asset=cur,
     )
     url = _invoice_url(inv)
     await cq.message.answer(tr(lang, "invoice_created"), reply_markup=vip_currency_kb(lang))
@@ -180,7 +181,7 @@ async def pay_chat(cq: CallbackQuery) -> None:
         plan_code="chat_30d",
         amount_usd=float(amount),
         meta=_build_meta(cq.from_user.id, "chat_30d", currency),
-        currency=currency,
+        asset=currency,
     )
     url = _invoice_url(inv)
     await cq.message.answer(tr(lang, "invoice_created"), reply_markup=donate_back_kb(lang))
@@ -228,7 +229,7 @@ async def donate_make_invoice(msg: Message, state: FSMContext) -> None:
         plan_code="donation",
         amount_usd=amount_usd,
         meta={"user_id": msg.from_user.id, "currency": cur, "kind": "donate", "bot_id": BOT_ID},
-        currency=cur,
+        asset=cur,
     )
     url = _invoice_url(inv)
     await msg.answer(tr(lang, "invoice_created"))
@@ -331,7 +332,7 @@ async def donate_finish(msg: Message, state: FSMContext):
         plan_code="donation",
         amount_usd=amount_usd,
         meta={"user_id": msg.from_user.id, "currency": cur, "kind": "donate", "bot_id": BOT_ID},
-        currency=cur,
+        asset=cur,
     )
     url = _invoice_url(inv)
     if url:


### PR DESCRIPTION
## Summary
- use `asset` instead of `currency` for CryptoBot invoices
- convert invoice amounts from USD to selected asset units
- update payment handlers for new API

## Testing
- `python -m pytest`
- `python -m py_compile modules/payments/service.py modules/payments/providers/cryptobot.py modules/payments/providers/__init__.py modules/payments/__init__.py modules/ui_membership/handlers.py`


------
https://chatgpt.com/codex/tasks/task_e_68b33eecf4f0832a9ae7d5b0ab754698