### PR TITLE
Add asset and currency logging for payments

### DIFF
--- a/modules/payments/service.py
+++ b/modules/payments/service.py
@@ -36,6 +36,11 @@ async def _cryptobot_convert_amount(amount_usd: float, asset: str) -> float:
     headers = {"Crypto-Pay-API-Token": CRYPTOBOT_TOKEN}
     timeout = aiohttp.ClientTimeout(total=20)
     async with aiohttp.ClientSession(headers=headers, timeout=timeout) as sess:
+        log.info(
+            "cryptobot getExchangeRates: asset=%s amount_usd=%s",
+            asset,
+            amount_usd,
+        )
         async with sess.get(f"{CRYPTOBOT_API}/getExchangeRates") as resp:
             text = await resp.text()
             try:
@@ -90,6 +95,12 @@ async def _cryptobot_create_invoice(
 
     timeout = aiohttp.ClientTimeout(total=20)
     async with aiohttp.ClientSession(headers=headers, timeout=timeout) as sess:
+        log.info(
+            "cryptobot createInvoice: asset=%s amount=%s (usd=%s)",
+            asset,
+            payload["amount"],
+            amount_usd,
+        )
         async with sess.post(f"{CRYPTOBOT_API}/createInvoice", json=payload) as resp:
             # Диагностика на случай неожиданных ответов
             text = await resp.text()

--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import logging
 from typing import Any, Dict, Optional
 
 from aiogram import F, Router
@@ -16,6 +17,8 @@ from modules.constants.currencies import CURRENCIES
 from modules.constants.paths import START_PHOTO
 from modules.payments import create_invoice
 from shared.utils.lang import get_lang
+
+log = logging.getLogger("juicyfox.ui_membership.handlers")
 
 # Клавиатуры текущего модуля
 from .keyboards import (
@@ -136,6 +139,12 @@ async def pay_vip(cq: CallbackQuery) -> None:
     lang = get_lang(cq.from_user)
     currency = "USDT"
     amount = VIP_PRICE_USD
+    log.info(
+        "pay_vip: user=%s currency=%s amount=%s",
+        cq.from_user.id,
+        currency,
+        amount,
+    )
     inv = await create_invoice(
         user_id=cq.from_user.id,
         plan_code="vip_30d",
@@ -159,6 +168,12 @@ async def vipay_currency(cq: CallbackQuery) -> None:
         await cq.answer("Unsupported currency", show_alert=True)
         return
 
+    log.info(
+        "vipay_currency: user=%s currency=%s amount=%s",
+        cq.from_user.id,
+        cur,
+        VIP_PRICE_USD,
+    )
     inv = await create_invoice(
         user_id=cq.from_user.id,
         plan_code="vip_30d",
@@ -176,6 +191,12 @@ async def pay_chat(cq: CallbackQuery) -> None:
     lang = get_lang(cq.from_user)
     currency = "USDT"
     amount = CHAT_PRICE_USD
+    log.info(
+        "pay_chat: user=%s currency=%s amount=%s",
+        cq.from_user.id,
+        currency,
+        amount,
+    )
     inv = await create_invoice(
         user_id=cq.from_user.id,
         plan_code="chat_30d",
@@ -224,6 +245,12 @@ async def donate_make_invoice(msg: Message, state: FSMContext) -> None:
     amount = float(raw)
 
     amount_usd = amount  # TODO: конверсия при необходимости
+    log.info(
+        "donate_make_invoice: user=%s currency=%s amount=%s",
+        msg.from_user.id,
+        cur,
+        amount_usd,
+    )
     inv = await create_invoice(
         user_id=msg.from_user.id,
         plan_code="donation",
@@ -327,6 +354,12 @@ async def donate_finish(msg: Message, state: FSMContext):
     data = await state.get_data()
     cur = data["currency"]
     amount_usd = amount  # TODO: конверсия при необходимости
+    log.info(
+        "donate_finish: user=%s currency=%s amount=%s",
+        msg.from_user.id,
+        cur,
+        amount_usd,
+    )
     inv = await create_invoice(
         user_id=msg.from_user.id,
         plan_code="donation",


### PR DESCRIPTION
## Summary
- log asset and amount before CryptoBot API calls
- log selected currency in VIP/chat/donation handlers before creating invoices

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3460ca314832aa74ca0ef9047c269