### PR TITLE
Add luxury currency keyboard

### DIFF
--- a/modules/ui_membership/keyboards.py
+++ b/modules/ui_membership/keyboards.py
@@ -32,6 +32,17 @@ def vip_currency_kb(lang: str | None = None) -> InlineKeyboardMarkup:
     return b.as_markup()
 
 
+def luxury_currency_kb(lang: str | None = None) -> InlineKeyboardMarkup:
+
+    """Меню выбора валюты для Luxury-подписки."""
+    b = InlineKeyboardBuilder()
+    for title, code in CURRENCIES:
+        b.button(text=title, callback_data=f"luxpay:{code}")
+    b.button(text=tr(lang or "en", "btn_back"), callback_data="ui:back")
+    b.adjust(3, 1)
+    return b.as_markup()
+
+
 
 def chat_plan_kb(lang: str | None = None) -> InlineKeyboardMarkup:
     """Экран Chat: кнопка оплаты (pay:chat) и Назад."""


### PR DESCRIPTION
## Summary
- add keyboard builder for luxury subscription currency selection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b34c451e80832a9afb7b351ceef00a