### PR TITLE
Add handler for luxury membership selection

### DIFF
--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -27,6 +27,7 @@ from .keyboards import (
     donate_kb,
     main_menu_kb,
     reply_menu,
+    luxury_currency_kb,
     vip_currency_kb,
 )
 
@@ -108,6 +109,15 @@ async def cmd_currency(message: Message) -> None:
 async def show_chat(cq: CallbackQuery) -> None:
     lang = get_lang(cq.from_user)
     await cq.message.edit_text(tr(lang, "chat_desc"), reply_markup=chat_plan_kb())
+
+
+@router.callback_query(F.data.in_({"ui:luxury", "luxury"}))
+async def show_luxury(cq: CallbackQuery) -> None:
+    lang = get_lang(cq.from_user)
+    await cq.message.edit_text(
+        tr(lang, "luxury_room_desc"),
+        reply_markup=luxury_currency_kb(lang),
+    )
 
 
 @router.callback_query(F.data.in_({"ui:life", "life"}))

--- a/modules/ui_membership/keyboards.py
+++ b/modules/ui_membership/keyboards.py
@@ -32,6 +32,16 @@ def vip_currency_kb(lang: str | None = None) -> InlineKeyboardMarkup:
     return b.as_markup()
 
 
+def luxury_currency_kb(lang: str | None = None) -> InlineKeyboardMarkup:
+    """Меню выбора валюты для Luxury-подписки."""
+    b = InlineKeyboardBuilder()
+    for title, code in CURRENCIES:
+        b.button(text=title, callback_data=f"payc:club:{code}")
+    b.button(text=tr(lang or "en", "btn_back"), callback_data="ui:back")
+    b.adjust(3, 1)
+    return b.as_markup()
+
+
 
 def chat_plan_kb(lang: str | None = None) -> InlineKeyboardMarkup:
     """Экран Chat: кнопка оплаты (pay:chat) и Назад."""


### PR DESCRIPTION
## Summary
- add callback handler for Luxury Room navigation showing description and currency options
- provide keyboard builder for selecting Luxury Room payment currencies

## Testing
- `pytest -q`
- `python -m py_compile modules/ui_membership/handlers.py modules/ui_membership/keyboards.py`


------
https://chatgpt.com/codex/tasks/task_e_68b34c4c4234832ab0f08a00c26d172b