### PR TITLE
Adjust VIP currency keyboard layout

### DIFF
--- a/modules/ui_membership/keyboards.py
+++ b/modules/ui_membership/keyboards.py
@@ -25,10 +25,12 @@ def vip_currency_kb(lang: str | None = None) -> InlineKeyboardMarkup:
 
     """Меню выбора валюты для VIP-подписки."""
     b = InlineKeyboardBuilder()
+    if len(CURRENCIES) != 8:
+        raise ValueError("CURRENCIES must contain exactly eight items")
     for title, code in CURRENCIES:
         b.button(text=title, callback_data=f"vipay:{code}")
     b.button(text=tr(lang or "en", "btn_back"), callback_data="ui:back")
-    b.adjust(3, 1)
+    b.adjust(2, 2, 2, 2, 1)
     return b.as_markup()
 
 


### PR DESCRIPTION
## Summary
- Ensure VIP currency keyboard lays out four rows of two currencies plus a final back row
- Validate that the currencies list contains exactly eight entries

## Testing
- `pytest`
- `python -m py_compile modules/ui_membership/keyboards.py`


------
https://chatgpt.com/codex/tasks/task_e_68b34e958c14832abed17a39f195c774