### PR TITLE
Remove VIP currency menu after invoice

### DIFF
--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -182,9 +182,12 @@ async def vipay_currency(cq: CallbackQuery) -> None:
         asset=cur,
     )
     url = _invoice_url(inv)
-    await cq.message.answer(tr(lang, "invoice_created"), reply_markup=vip_currency_kb(lang))
+    await cq.message.answer(tr(lang, "invoice_created"))
     if url:
         await cq.message.answer(url)
+    kb = InlineKeyboardBuilder()
+    kb.button(text=tr(lang, "btn_back"), callback_data="ui:back")
+    await cq.message.answer(tr(lang, "back"), reply_markup=kb.as_markup())
 
 @router.callback_query(F.data == "pay:chat")
 async def pay_chat(cq: CallbackQuery) -> None:


### PR DESCRIPTION
## Summary
- Simplify VIP payment flow: remove currency keyboard after invoice creation
- Offer a separate back button message after providing the invoice URL

## Testing
- `pytest`
- `python -m py_compile modules/ui_membership/handlers.py`


------
https://chatgpt.com/codex/tasks/task_e_68b34eb7c1a0832ab4ae0c3ee7473a21