### PR TITLE
Add chat tariff selection handler and keyboard

### DIFF
--- a/apps/bot_core/routers.py
+++ b/apps/bot_core/routers.py
@@ -50,7 +50,7 @@ def register(dp, cfg: Any = None) -> None:
 
     # UI / меню / донаты / VIP / чат — базовый модуль
     with suppress(Exception):
-        from modules.ui_membership.handlers import router as ui_router
+        from modules.ui_membership import router as ui_router
         dp.include_router(ui_router)
 
     # Планирование и постинг

--- a/modules/ui_membership/__init__.py
+++ b/modules/ui_membership/__init__.py
@@ -1,1 +1,10 @@
-from .handlers import router
+from aiogram import Router
+
+from .handlers import router as main_router
+from .chat_handlers import router as chat_router
+
+router = Router()
+router.include_router(main_router)
+router.include_router(chat_router)
+
+__all__ = ("router",)

--- a/modules/ui_membership/chat_handlers.py
+++ b/modules/ui_membership/chat_handlers.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from aiogram import F, Router
+from aiogram.types import CallbackQuery
+
+from modules.common.i18n import tr
+from shared.utils.lang import get_lang
+
+from .chat_keyboards import chat_tariffs_kb
+
+router = Router()
+
+
+@router.callback_query(F.data.in_({"ui:chat", "chat"}))
+async def show_chat(cq: CallbackQuery) -> None:
+    lang = get_lang(cq.from_user)
+    await cq.message.edit_text(
+        tr(lang, "chat_access"),
+        reply_markup=chat_tariffs_kb(lang),
+    )

--- a/modules/ui_membership/chat_keyboards.py
+++ b/modules/ui_membership/chat_keyboards.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+from aiogram.types import InlineKeyboardMarkup
+
+from modules.common.i18n import tr
+
+
+def chat_tariffs_kb(lang: str) -> InlineKeyboardMarkup:
+    b = InlineKeyboardBuilder()
+    b.button(text=tr(lang, "chat_flower_1"), callback_data="chatplan:7d")
+    b.button(text=tr(lang, "chat_flower_2"), callback_data="chatplan:15d")
+    b.button(text=tr(lang, "chat_flower_3"), callback_data="chatplan:30d")
+    b.button(text=tr(lang, "back"), callback_data="ui:back")
+    b.adjust(1, 1, 1, 1)
+    return b.as_markup()

--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -17,6 +17,7 @@ from modules.constants.currencies import CURRENCIES
 from modules.constants.paths import START_PHOTO
 from modules.payments import create_invoice
 from shared.utils.lang import get_lang
+from modules.common.shared import ChatGift
 
 log = logging.getLogger("juicyfox.ui_membership.handlers")
 
@@ -29,6 +30,7 @@ from .keyboards import (
     reply_menu,
     vip_currency_kb,
 )
+from .chat_keyboards import chat_tariffs_kb
 
 router = Router()
 
@@ -102,12 +104,6 @@ async def cmd_currency(message: Message) -> None:
         tr(lang, "choose_cur", amount=VIP_PRICE_USD),
         reply_markup=vip_currency_kb(lang),
     )
-
-
-@router.callback_query(F.data.in_({"ui:chat", "chat"}))
-async def show_chat(cq: CallbackQuery) -> None:
-    lang = get_lang(cq.from_user)
-    await cq.message.edit_text(tr(lang, "chat_desc"), reply_markup=chat_plan_kb())
 
 
 @router.callback_query(F.data.in_({"ui:life", "life"}))
@@ -382,7 +378,7 @@ async def donate_finish(msg: Message, state: FSMContext):
 async def handle_chat_btn(msg: Message, state: FSMContext):
     lang = get_lang(msg.from_user)
     await state.set_state(ChatGift.plan)
-    await msg.answer(tr(lang, "chat_access"), reply_markup=chat_plan_kb(lang))
+    await msg.answer(tr(lang, "chat_access"), reply_markup=chat_tariffs_kb(lang))
 
 
 @router.message(F.text == "💎 Luxury Room – 15$")


### PR DESCRIPTION
## Summary
- Add dedicated chat router with tariff selection handler
- Provide chat_tariffs_kb keyboard for 7/15/30 day plans
- Register new router in ui_membership and core router registry

## Testing
- `python -m py_compile modules/ui_membership/chat_handlers.py modules/ui_membership/chat_keyboards.py modules/ui_membership/handlers.py modules/ui_membership/__init__.py apps/bot_core/routers.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b35915c3d8832a934795b44275b055