### PR TITLE
Refactor chat access handling

### DIFF
--- a/modules/ui_membership/keyboards.py
+++ b/modules/ui_membership/keyboards.py
@@ -44,17 +44,6 @@ def luxury_currency_kb(lang: str | None = None) -> InlineKeyboardMarkup:
     b.adjust(3, 1)
     return b.as_markup()
 
-
-
-def chat_plan_kb(lang: str | None = None) -> InlineKeyboardMarkup:
-    """Экран Chat: кнопка оплаты (pay:chat) и Назад."""
-    b = InlineKeyboardBuilder()
-    b.button(text=tr(lang or "en", "btn_pay_chat"), callback_data="pay:chat")
-    b.button(text=tr(lang or "en", "btn_back"), callback_data="ui:back")
-    b.adjust(1)
-    return b.as_markup()
-
-
 def donate_kb(lang: str | None = None) -> InlineKeyboardMarkup:
     """Выбор валюты для доната: donate:cur:<CODE> + Назад."""
     b = InlineKeyboardBuilder()


### PR DESCRIPTION
## Summary
- remove legacy chat reply and pay_chat flow
- add localized btn_chat handler to show tariffs keyboard
- drop unused chat_plan_kb and pay:chat

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3f7b83f24832abf87169f3055a79a