### PR TITLE
Refactor membership invoice metadata

### DIFF
--- a/modules/ui_membership/chat_handlers.py
+++ b/modules/ui_membership/chat_handlers.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any, Optional
 
 from aiogram import F, Router
@@ -13,6 +11,7 @@ from modules.payments import create_invoice
 from shared.utils.lang import get_lang
 
 from .chat_keyboards import chat_tariffs_kb, chat_currency_kb
+from .utils import _build_meta
 
 router = Router()
 
@@ -77,8 +76,8 @@ async def paymem_currency(cq: CallbackQuery) -> None:
         user_id=cq.from_user.id,
         plan_code=plan_code,
         amount_usd=float(amount),
+        meta=_build_meta(cq.from_user.id, plan_code, asset),
         asset=asset,
-        meta={"plan": plan_code, "asset": asset},
     )
 
     url = _invoice_url(inv)

--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from aiogram import F, Router
 from aiogram.filters import Command
@@ -31,12 +31,12 @@ from .keyboards import (
 )
 from .chat_keyboards import chat_tariffs_kb
 from .chat_handlers import router as chat_router
+from .utils import BOT_ID, _build_meta
 
 router = Router()
 router.include_router(chat_router)
 
 # --- Конфиг из ENV (позже переедет в shared.config.env) ---
-BOT_ID = os.getenv("BOT_ID", "sample")
 VIP_URL = os.getenv("VIP_URL")
 LIFE_URL = os.getenv("LIFE_URL")
 
@@ -118,8 +118,6 @@ async def show_life_link(cq: CallbackQuery) -> None:
 # =======================
 # Оплата подписок (VIP/Chat)
 # =======================
-def _build_meta(user_id: int, plan_code: str, currency: str) -> Dict[str, Any]:
-    return {"user_id": user_id, "plan_code": plan_code, "currency": currency, "bot_id": BOT_ID}
 
 def _invoice_url(inv: Any) -> Optional[str]:
     """Поддерживаем и dict с 'pay_url', и просто строку-URL."""

--- a/modules/ui_membership/utils.py
+++ b/modules/ui_membership/utils.py
@@ -1,0 +1,14 @@
+import os
+from typing import Any, Dict
+
+BOT_ID = os.getenv("BOT_ID", "sample")
+
+
+def _build_meta(user_id: int, plan_code: str, currency: str) -> Dict[str, Any]:
+    """Compose invoice metadata shared across membership flows."""
+    return {
+        "user_id": user_id,
+        "plan_code": plan_code,
+        "currency": currency,
+        "bot_id": BOT_ID,
+    }


### PR DESCRIPTION
## Summary
- centralize `_build_meta` into a shared `utils` module for membership handlers
- use `_build_meta` when generating chat membership invoices for consistent metadata
- ensure payment handlers call `create_invoice` with matching plan, amount, and asset parameters

## Testing
- `python -m py_compile modules/ui_membership/utils.py modules/ui_membership/handlers.py modules/ui_membership/chat_handlers.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3f899f888832abc2969947ee8de3c