### PR TITLE
Hide Luxury Room button

### DIFF
--- a/modules/ui_membership/keyboards.py
+++ b/modules/ui_membership/keyboards.py
@@ -13,11 +13,11 @@ def main_menu_kb(lang: str) -> InlineKeyboardMarkup:
     """Главное меню: Life, Luxury, VIP, Donate, Chat."""
     b = InlineKeyboardBuilder()
     b.button(text=tr(lang, "btn_life"), callback_data="ui:life")
-    b.button(text=tr(lang, "btn_lux"), callback_data="ui:luxury")
+    # b.button(text=tr(lang, "btn_lux"), callback_data="ui:luxury")  # temporarily hidden
     b.button(text=tr(lang, "btn_vip"), callback_data="ui:vip")
     b.button(text=tr(lang, "btn_donate"), callback_data="donate")
     b.button(text=tr(lang, "btn_chat"), callback_data="ui:chat")
-    b.adjust(2, 2, 1)
+    b.adjust(2, 2)
     return b.as_markup()
 
 
@@ -68,13 +68,14 @@ def reply_menu(lang: str) -> ReplyKeyboardMarkup:
     Можно показывать всегда — это не ломает inline-сценарии.
     """
     chat_label = tr(lang, "btn_chat")
-    luxury_label = tr(lang, "btn_lux")
+    # luxury_label = tr(lang, "btn_lux")  # temporarily hidden
     vip_label = tr(lang, "btn_vip")
 
     return ReplyKeyboardMarkup(
         keyboard=[
             [KeyboardButton(text=chat_label)],
-            [KeyboardButton(text=luxury_label), KeyboardButton(text=vip_label)],
+            # [KeyboardButton(text=luxury_label), KeyboardButton(text=vip_label)],  # temporarily hidden
+            [KeyboardButton(text=vip_label)],
         ],
         resize_keyboard=True,
         one_time_keyboard=False,


### PR DESCRIPTION
## Summary
- temporarily remove Luxury Room button from main menu and reply keyboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4b8ca83fc832a83a9c842e83c93f7