### PR TITLE
Rename chat and VIP buttons

### DIFF
--- a/modules/common/i18n.py
+++ b/modules/common/i18n.py
@@ -13,8 +13,8 @@ for lang in ("ru", "en", "es"):
 BUTTONS = {
     "btn_life": "👀 Juicy Life - Free",
     "btn_lux": "💎 Luxury Room - 15 $",
-    "btn_vip": "❤️‍🔥 VIP Secret - 35 $",
-    "btn_chat": "💬 Juicy Chat",
+    "btn_vip": "VIP CLUB 🔞 - 19 $",
+    "btn_chat": "SEE YOU СHAT 💬",
     "btn_donate": "🎁 Custom",
     "btn_see_chat": "SEE YOU MY CHAT💬",
     "btn_back": "⬅️ Back",

--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -292,7 +292,8 @@ async def legacy_reply_luxury(msg: Message) -> None:
     await msg.answer(tr(lang, "luxury_room_desc"), reply_markup=kb.as_markup())
 
 @router.message(lambda m: _norm(m.text) in {
-    _norm(tr(get_lang(m.from_user), "btn_vip")) or "❤️‍🔥 VIP Secret - 35 $"
+    _norm(tr(get_lang(m.from_user), "btn_vip")),
+    "❤️‍🔥 VIP Secret - 35 $",
 })
 async def legacy_reply_vip(msg: Message) -> None:
     lang = get_lang(msg.from_user)
@@ -397,7 +398,7 @@ async def luxury_room_reply(msg: Message):
     await msg.answer(tr(lang, "luxury_room_desc"), reply_markup=kb.as_markup())
 
 
-@router.message(F.text == "❤️‍🔥 VIP Secret - 35 $")
+@router.message(F.text.in_({"VIP CLUB 🔞 - 19 $", "❤️‍🔥 VIP Secret - 35 $"}))
 async def vip_secret_reply(msg: Message):
     lang = get_lang(msg.from_user)
     await msg.answer(tr(lang, "vip_secret_desc"), reply_markup=vip_currency_kb())


### PR DESCRIPTION
## Summary
- Rename default chat and VIP button labels
- Handle legacy VIP button text for users with cached keyboards

## Testing
- `python -m py_compile modules/common/i18n.py modules/ui_membership/handlers.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4c08aeb40832a816cbce0028e400c