### PR TITLE
Rename Custom button to DONATE and move to reply

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -4,7 +4,7 @@
   "btn_lux": "💎 Luxury Room - 15 $",
   "btn_vip": "VIP CLUB 🔞 - 19 $",
   "btn_chat": "SEE YOU СHAT 💬",
-  "btn_donate": "🎁 Custom",
+  "btn_donate": "DONATE 🎁",
   "tip_menu": "🛍 Tip Menu",
   "activate_chat": "See you my chaT 💬",
   "life_link": "👀 My channel: {url}",

--- a/locales/es.json
+++ b/locales/es.json
@@ -4,7 +4,7 @@
   "btn_lux": "💎 Luxury Room - 15 $",
   "btn_vip": "VIP CLUB 🔞 - 19 $",
   "btn_chat": "SEE YOU СHAT 💬",
-  "btn_donate": "🎁 Personalizado",
+  "btn_donate": "DONATE 🎁",
   "tip_menu": "🛍 Menú de propinas",
   "activate_chat": "See you my chaT 💬",
   "life_link": "👀 Mi canal: {url}",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -4,7 +4,7 @@
   "btn_lux": "💎 Luxury Room - 15 $",
   "btn_vip": "VIP CLUB 🔞 - 19 $",
   "btn_chat": "SEE YOU СHAT 💬",
-  "btn_donate": "🎁 Custom",
+  "btn_donate": "DONATE 🎁",
   "tip_menu": "🛍 Tip Menu",
   "activate_chat": "See you my chaT 💬",
   "life_link": "👀 Мой канал: {url}",

--- a/modules/common/i18n.py
+++ b/modules/common/i18n.py
@@ -15,7 +15,7 @@ BUTTONS = {
     "btn_lux": "💎 Luxury Room - 15 $",
     "btn_vip": "❤️‍🔥 VIP Secret - 35 $",
     "btn_chat": "💬 Juicy Chat",
-    "btn_donate": "🎁 Custom",
+    "btn_donate": "DONATE 🎁",
     "btn_see_chat": "SEE YOU MY CHAT💬",
     "btn_back": "⬅️ Back",
     "btn_pay_vip": "💳 Pay VIP",

--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -210,11 +210,11 @@ async def vipay_currency(callback: CallbackQuery, state: FSMContext) -> None:
 # =======================
 # Донаты
 # =======================
-@router.callback_query(F.data.in_({"donate", "ui:tip"}))
-async def donate_currency(cq: CallbackQuery, state: FSMContext) -> None:
+@router.message(lambda m: (m.text or "").strip() == tr(get_lang(m.from_user), "btn_donate"))
+async def donate_currency(msg: Message, state: FSMContext) -> None:
     await state.set_state(Donate.choosing_currency)
-    await cq.message.edit_text(
-        tr(get_lang(cq.from_user), "choose_cur", amount="donate"),
+    await msg.answer(
+        tr(get_lang(msg.from_user), "choose_cur", amount="donate"),
         reply_markup=donate_kb(),
     )
 
@@ -311,7 +311,7 @@ async def back_to_main(cq: CallbackQuery):
     lang = get_lang(cq.from_user)
     await cq.message.edit_text(tr(lang, "choose_action"), reply_markup=main_menu_kb(lang))
 
-
+"""
 @router.callback_query(F.data == "donate")
 async def donate_currency(cq: CallbackQuery, state: FSMContext):
     await cq.message.edit_text(
@@ -375,7 +375,7 @@ async def donate_finish(msg: Message, state: FSMContext):
     else:
         await msg.reply(tr(get_lang(msg.from_user), "inv_err"))
     await state.clear()
-
+"""
 
 @router.message(
     lambda m: _norm(m.text) == _norm(tr(get_lang(m.from_user), "btn_chat"))

--- a/modules/ui_membership/keyboards.py
+++ b/modules/ui_membership/keyboards.py
@@ -10,14 +10,13 @@ from modules.constants.currencies import CURRENCIES
 # ---------- INLINE КНОПКИ (стабильные callback'и) ----------
 
 def main_menu_kb(lang: str) -> InlineKeyboardMarkup:
-    """Главное меню: Life, Luxury, VIP, Donate, Chat."""
+    """Главное меню: Life, Luxury, VIP, Chat."""
     b = InlineKeyboardBuilder()
     b.button(text=tr(lang, "btn_life"), callback_data="ui:life")
     # b.button(text=tr(lang, "btn_lux"), callback_data="ui:luxury")  # temporarily hidden
     b.button(text=tr(lang, "btn_vip"), callback_data="ui:vip")
-    b.button(text=tr(lang, "btn_donate"), callback_data="donate")
     b.button(text=tr(lang, "btn_chat"), callback_data="ui:chat")
-    b.adjust(2, 2)
+    b.adjust(2, 1)
     return b.as_markup()
 
 
@@ -70,12 +69,14 @@ def reply_menu(lang: str) -> ReplyKeyboardMarkup:
     chat_label = tr(lang, "btn_chat")
     # luxury_label = tr(lang, "btn_lux")  # temporarily hidden
     vip_label = tr(lang, "btn_vip")
+    donate_label = tr(lang, "btn_donate")
 
     return ReplyKeyboardMarkup(
         keyboard=[
             [KeyboardButton(text=chat_label)],
             # [KeyboardButton(text=luxury_label), KeyboardButton(text=vip_label)],  # temporarily hidden
             [KeyboardButton(text=vip_label)],
+            [KeyboardButton(text=donate_label)],
         ],
         resize_keyboard=True,
         one_time_keyboard=False,


### PR DESCRIPTION
## Summary
- rename Custom button to DONATE 🎁 in locales and defaults
- move donate button from inline menu to third-level reply menu
- handle DONATE via reply message

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4c0daa098832aa834c436c833489e