### PR TITLE
Prioritize VIP CLUB description when canceling payments

### DIFF
--- a/modules/payments/handlers.py
+++ b/modules/payments/handlers.py
@@ -30,7 +30,10 @@ async def cancel_payment(callback: CallbackQuery, state: FSMContext) -> None:
         return
 
     # Determine the description and keyboard to restore based on the plan callback
-    if plan_cb.startswith("vipay"):
+    if plan_name == "VIP CLUB":
+        desc = tr(lang, "vip_club_description")
+        kb = vip_currency_kb(lang)
+    elif plan_cb.startswith("vipay"):
         desc = tr(lang, "vip_secret_desc")
         kb = vip_currency_kb(lang)
     elif plan_cb.startswith("paymem:"):
@@ -43,17 +46,13 @@ async def cancel_payment(callback: CallbackQuery, state: FSMContext) -> None:
             builder.button(text=title, callback_data=f"{plan_cb}:{code}")
         builder.button(text=tr(lang, "btn_back"), callback_data="ui:back")
         builder.adjust(2, 2, 2, 2, 1)
-        tariff_desc = tr(
+        desc = tr(
             lang,
             "tariff_desc",
             plan_name=plan_name or "",
             price=price,
             period=period or 0,
         )
-        if plan_name == "VIP CLUB":
-            desc = tr(lang, "vip_club_description")
-        else:
-            desc = tariff_desc
         kb = builder.as_markup()
 
     # Replace the invoice with the original tariff description and currency menu


### PR DESCRIPTION
## Summary
- Ensure `cancel_payment` checks for the VIP CLUB plan before VIP Secret handling
- Send `vip_club_description` for VIP CLUB cancellations while preserving keyboard logic

## Testing
- `python -m py_compile juicyfox_bot/modules/payments/handlers.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4e9e6c48c832ab1d13b67251640f8