### PR TITLE
Use vip_club_description key for VIP menu

### DIFF
--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -97,7 +97,7 @@ async def back_to_main(cq: CallbackQuery) -> None:
 @router.callback_query(F.data.in_({"ui:vip", "vip"}))
 async def show_vip(cq: CallbackQuery) -> None:
     lang = get_lang(cq.from_user)
-    await cq.message.edit_text(tr(lang, "vip_secret_desc"), reply_markup=vip_currency_kb(lang))
+    await cq.message.edit_text(tr(lang, "vip_club_description"), reply_markup=vip_currency_kb(lang))
 
 
 @router.message(Command("currency"))


### PR DESCRIPTION
## Summary
- display VIP club description via `vip_club_description` translation key

## Testing
- `python - <<'PY'
import json, glob
missing = []
for f in glob.glob('locales/*.json'):
    with open(f) as fp:
        data = json.load(fp)
    if 'vip_club_description' not in data:
        missing.append(f)
print('Missing:' if missing else 'All locales have vip_club_description', missing)
PY`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4eb12f658832aac5d268bc78390d2