### PR TITLE
Add diagnostic plan_name logging

### DIFF
--- a/modules/payments/handlers.py
+++ b/modules/payments/handlers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 from aiogram import F, Router
 from aiogram.fsm.context import FSMContext
 from aiogram.types import CallbackQuery
@@ -12,6 +14,7 @@ from modules.ui_membership.keyboards import vip_currency_kb
 from shared.utils.lang import get_lang
 
 
+log = logging.getLogger("juicyfox.payments.handlers")
 router = Router()
 
 
@@ -24,6 +27,8 @@ async def cancel_payment(callback: CallbackQuery, state: FSMContext) -> None:
     plan_name = data.get("plan_name")
     price = data.get("price")
     period = data.get("period")
+
+    log.debug("Retrieved plan_name from state: %s", plan_name)
 
     if not plan_cb or price is None:
         await callback.answer(tr(lang, "nothing_cancel"), show_alert=True)

--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -143,6 +143,8 @@ async def pay_vip(callback: CallbackQuery, state: FSMContext) -> None:
         period=30,
         plan_callback="vipay",
     )
+    data = await state.get_data()
+    log.debug("Saved plan_name: %s", data.get("plan_name"))
     log.info(
         "pay_vip: user=%s currency=%s amount=%s",
         callback.from_user.id,
@@ -191,6 +193,8 @@ async def vipay_currency(callback: CallbackQuery, state: FSMContext) -> None:
         period=30,
         plan_callback="vipay",
     )
+    data = await state.get_data()
+    log.debug("Saved plan_name: %s", data.get("plan_name"))
     inv = await create_invoice(
         user_id=callback.from_user.id,
         plan_code="vip_30d",


### PR DESCRIPTION
## Summary
- add debug logging after storing plan_name in UI membership FSM
- log plan_name on payment cancel to verify data from FSM

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4ebfeb2a4832a8b88e1701315ab04