### PR TITLE
Add donate button and callback handler

### DIFF
--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -219,8 +219,19 @@ async def vipay_currency(callback: CallbackQuery, state: FSMContext) -> None:
 # =======================
 # Донаты
 # =======================
+@router.callback_query(F.data == "ui:donate")
+async def donate_menu(cq: CallbackQuery, state: FSMContext) -> None:
+    await state.clear()
+    lang = get_lang(cq.from_user)
+    await cq.message.edit_text(
+        tr(lang, "donate_menu"),
+        reply_markup=donate_keyboard(lang),
+    )
+
+
 @router.message(lambda m: (m.text or "").strip() == tr(get_lang(m.from_user), "btn_donate"))
-async def donate_menu(msg: Message, state: FSMContext) -> None:
+async def donate_menu_legacy(msg: Message, state: FSMContext) -> None:
+    """Legacy reply-keyboard support."""
     await state.clear()
     lang = get_lang(msg.from_user)
     await msg.answer(

--- a/modules/ui_membership/keyboards.py
+++ b/modules/ui_membership/keyboards.py
@@ -16,7 +16,8 @@ def main_menu_kb(lang: str) -> InlineKeyboardMarkup:
     # b.button(text=tr(lang, "btn_lux"), callback_data="ui:luxury")  # temporarily hidden
     b.button(text=tr(lang, "btn_vip"), callback_data="ui:vip")
     b.button(text=tr(lang, "btn_chat"), callback_data="ui:chat")
-    b.adjust(2, 1)
+    b.button(text=tr(lang, "btn_donate"), callback_data="ui:donate")
+    b.adjust(2, 1, 1)
     return b.as_markup()
 
 


### PR DESCRIPTION
## Summary
- add donate button to membership main menu
- handle donate option via callback and keep legacy reply handler

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b563ad0cdc832a88835901ab52195e