### PR TITLE
Improve donation cancel flow

### DIFF
--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -28,6 +28,7 @@ from .keyboards import (
     vip_currency_kb,
     donate_keyboard,
     donate_currency_keyboard,
+    donate_invoice_keyboard,
 )
 from .chat_keyboards import chat_tariffs_kb
 from .chat_handlers import router as chat_router
@@ -259,18 +260,16 @@ async def donate_set_currency(cq: CallbackQuery, state: FSMContext) -> None:
     )
     url = _invoice_url(inv)
     if url:
-        kb = InlineKeyboardMarkup(
-            inline_keyboard=[[InlineKeyboardButton(text=tr(lang, "btn_cancel"), callback_data="cancel")]]
-        )
-        await cq.message.answer(
+        await cq.message.edit_text(
             tr(lang, "invoice_message", plan="Donate", url=url),
-            reply_markup=kb,
+            reply_markup=donate_invoice_keyboard(lang),
         )
+        await state.set_state(Donate.confirm)
     else:
         await cq.message.answer(tr(lang, "inv_err"))
-    await state.clear()
 
 @router.callback_query(F.data == "donate_cancel")
+@router.callback_query(Donate.confirm)
 async def cancel_donate(callback: CallbackQuery, state: FSMContext) -> None:
     lang = get_lang(callback.from_user)
     await state.clear()

--- a/modules/ui_membership/keyboards.py
+++ b/modules/ui_membership/keyboards.py
@@ -81,6 +81,12 @@ def donate_currency_keyboard(lang: str | None = None) -> InlineKeyboardMarkup:
     )
     return kb
 
+
+def donate_invoice_keyboard(lang: str | None = None) -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[[InlineKeyboardButton(text=tr(lang or "en", "btn_cancel"), callback_data="donate_cancel")]]
+    )
+
 def donate_kb(lang: str | None = None) -> InlineKeyboardMarkup:
     """Выбор валюты для доната: donate:cur:<CODE> + Назад."""
     b = InlineKeyboardBuilder()


### PR DESCRIPTION
## Summary
- allow cancelling donation after invoice creation
- show cancel button via new `donate_invoice_keyboard`
- restore donation menu on cancel

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b564369fc8832a8d3de62068dd4851