### PR TITLE
Add back navigation for donation flow

### DIFF
--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -251,6 +251,15 @@ async def donate_currency(cq: CallbackQuery, state: FSMContext) -> None:
         reply_markup=donate_currency_keyboard(lang),
     )
 
+@router.callback_query(F.data == "donate_back", Donate.choosing_currency)
+async def donate_back(cq: CallbackQuery, state: FSMContext) -> None:
+    """Return to amount selection without clearing state."""
+    lang = get_lang(cq.from_user)
+    await cq.message.edit_text(
+        tr(lang, "donate_menu"),
+        reply_markup=donate_keyboard(lang),
+    )
+
 @router.callback_query(F.data.startswith("donate$"), Donate.choosing_currency)
 async def donate_set_currency(cq: CallbackQuery, state: FSMContext) -> None:
     # ожидаем формат donate$<ASSET>, например donate$USDT

--- a/modules/ui_membership/keyboards.py
+++ b/modules/ui_membership/keyboards.py
@@ -68,6 +68,7 @@ def donate_keyboard(lang: str | None = None) -> InlineKeyboardMarkup:
              InlineKeyboardButton(text="100$", callback_data="donate_100"),
              InlineKeyboardButton(text="200$", callback_data="donate_200")],
             [InlineKeyboardButton(text="500$", callback_data="donate_500")],
+            [InlineKeyboardButton(text=tr(lang or "en", "btn_back"), callback_data="ui:back")],
         ]
     )
 
@@ -78,15 +79,15 @@ def donate_currency_keyboard(lang: str | None = None) -> InlineKeyboardMarkup:
         for btn in row:
             btn.callback_data = f"donate${btn.callback_data.split(':', 1)[1]}"
     kb.inline_keyboard[-1][0] = InlineKeyboardButton(
-        text=tr(lang or "en", "btn_cancel"), callback_data="donate_cancel"
+        text=tr(lang or "en", "btn_back"), callback_data="donate_back"
     )
     return kb
 
 
 def donate_invoice_keyboard(lang: str | None = None) -> InlineKeyboardMarkup:
-    return InlineKeyboardMarkup(
-        inline_keyboard=[[InlineKeyboardButton(text=tr(lang or "en", "btn_cancel"), callback_data="donate_cancel")]]
-    )
+    b = InlineKeyboardBuilder()
+    b.button(text=tr(lang or "en", "btn_cancel"), callback_data="donate_cancel")
+    return b.as_markup()
 
 def donate_kb(lang: str | None = None) -> InlineKeyboardMarkup:
     """Выбор валюты для доната: donate:cur:<CODE> + Назад."""


### PR DESCRIPTION
## Summary
- add Back button to donation amount keyboard
- allow returning to donation amount selection via new handler and keyboard back button
- implement separate invoice keyboard with cancel option

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b565297eb8832a938b14b944b4c44a