### PR TITLE
Improve donation flow state management

### DIFF
--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -222,7 +222,8 @@ async def vipay_currency(callback: CallbackQuery, state: FSMContext) -> None:
 # =======================
 @router.callback_query(F.data == "ui:donate")
 async def donate_menu(cq: CallbackQuery, state: FSMContext) -> None:
-    await state.clear()
+    # start donation flow without dropping stored data
+    await state.set_state(None)
     lang = get_lang(cq.from_user)
     await cq.message.edit_text(
         tr(lang, "donate_menu"),
@@ -233,7 +234,7 @@ async def donate_menu(cq: CallbackQuery, state: FSMContext) -> None:
 @router.message(lambda m: (m.text or "").strip() == tr(get_lang(m.from_user), "btn_donate"))
 async def donate_menu_legacy(msg: Message, state: FSMContext) -> None:
     """Legacy reply-keyboard support."""
-    await state.clear()
+    await state.set_state(None)
     lang = get_lang(msg.from_user)
     await msg.answer(
         tr(lang, "donate_menu"),
@@ -253,7 +254,8 @@ async def donate_currency(cq: CallbackQuery, state: FSMContext) -> None:
 
 @router.callback_query(F.data == "donate_back", Donate.choosing_currency)
 async def donate_back(cq: CallbackQuery, state: FSMContext) -> None:
-    """Return to amount selection without clearing state."""
+    """Go back to amount selection and reset state to start."""
+    await state.set_state(None)
     lang = get_lang(cq.from_user)
     await cq.message.edit_text(
         tr(lang, "donate_menu"),


### PR DESCRIPTION
## Summary
- keep donation amount in FSM when selecting currency
- add Back handler for currency step that resets state
- clear donation FSM only on cancel

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b56850aee4832a9017b247d504d88d