### PR TITLE
Add donate option to membership menu and reset state on back

### DIFF
--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -84,7 +84,9 @@ async def cmd_start(message: Message, state: FSMContext) -> None:
 
 
 @router.callback_query(F.data.in_({"ui:back", "back_to_main", "back"}))
-async def back_to_main(cq: CallbackQuery) -> None:
+async def back_to_main(cq: CallbackQuery, state: FSMContext) -> None:
+    """Return to main menu and reset any conversation state."""
+    await state.clear()
     lang = get_lang(cq.from_user)
     await cq.message.edit_text(
         tr(lang, "choose_action"),

--- a/modules/ui_membership/keyboards.py
+++ b/modules/ui_membership/keyboards.py
@@ -17,7 +17,7 @@ def main_menu_kb(lang: str) -> InlineKeyboardMarkup:
     b.button(text=tr(lang, "btn_vip"), callback_data="ui:vip")
     b.button(text=tr(lang, "btn_chat"), callback_data="ui:chat")
     b.button(text=tr(lang, "btn_donate"), callback_data="ui:donate")
-    b.adjust(2, 1, 1)
+    b.adjust(2, 2)
     return b.as_markup()
 
 


### PR DESCRIPTION
## Summary
- include donation button in membership main menu
- clear conversation state when using the global back button

## Testing
- `pytest`
- `python -m py_compile modules/ui_membership/keyboards.py modules/ui_membership/handlers.py`


------
https://chatgpt.com/codex/tasks/task_e_68b569146c18832a82295b107a9de3bb