### PR TITLE
Fix DONATE invoice cancel callback

### DIFF
--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -243,7 +243,7 @@ async def donate_menu_legacy(msg: Message, state: FSMContext) -> None:
         reply_markup=donate_keyboard(lang),
     )
 
-@router.callback_query(F.data.startswith("donate_"))
+@router.callback_query(F.data.regexp(r"^donate_\d+$"))
 async def donate_currency(cq: CallbackQuery, state: FSMContext) -> None:
     amount = int(cq.data.split("_", 1)[1])
     await state.update_data(amount=amount)

--- a/modules/ui_membership/keyboards.py
+++ b/modules/ui_membership/keyboards.py
@@ -85,6 +85,7 @@ def donate_currency_keyboard(lang: str | None = None) -> InlineKeyboardMarkup:
 
 
 def donate_invoice_keyboard(lang):
+    """Invoice screen with a dedicated cancel callback."""
     return InlineKeyboardMarkup(
         inline_keyboard=[
             [InlineKeyboardButton(text="❌ Cancel", callback_data="donate_cancel_invoice")]


### PR DESCRIPTION
## Summary
- use dedicated `donate_cancel_invoice` callback on invoice
- skip non-amount donate callbacks to avoid ValueError
- allow cancelling invoice to return to currency menu without losing state

## Testing
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b572d6a284832a97ee0db8d778d98b