### PR TITLE
Add Pay button to donation invoice

### DIFF
--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -282,11 +282,11 @@ async def donate_set_currency(cq: CallbackQuery, state: FSMContext) -> None:
         meta={"user_id": cq.from_user.id, "currency": cur, "kind": "donate", "bot_id": BOT_ID},
         asset=cur,
     )
-    url = _invoice_url(inv)
-    if url:
+    invoice_url = _invoice_url(inv)
+    if invoice_url:
         await cq.message.edit_text(
-            tr(lang, "invoice_message", plan="Donate", url=url),
-            reply_markup=donate_invoice_keyboard(lang),
+            tr(lang, "invoice_message", plan="Donate", url=invoice_url),
+            reply_markup=donate_invoice_keyboard(lang, invoice_url),
         )
         await state.set_state(Donate.confirm)
     else:

--- a/modules/ui_membership/keyboards.py
+++ b/modules/ui_membership/keyboards.py
@@ -84,10 +84,11 @@ def donate_currency_keyboard(lang: str | None = None) -> InlineKeyboardMarkup:
     return kb
 
 
-def donate_invoice_keyboard(lang):
+def donate_invoice_keyboard(lang, url: str):
     return InlineKeyboardMarkup(
         inline_keyboard=[
-            [InlineKeyboardButton(text="❌ Cancel", callback_data="donate_cancel_invoice")]
+            [InlineKeyboardButton(text="\U0001F4B3 Pay", url=url)],
+            [InlineKeyboardButton(text="\u274C Cancel", callback_data="donate_cancel_invoice")]
         ]
     )
 


### PR DESCRIPTION
## Summary
- add Pay button in donation invoice keyboard for quick access to invoice URL
- update donate handler to use invoice keyboard with Pay link

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b57624ef08832a8928b65bdcbe2493