### PR TITLE
chore: remove unused variable in donation cancel handler

### DIFF
--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -295,7 +295,6 @@ async def donate_set_currency(cq: CallbackQuery, state: FSMContext) -> None:
 @router.callback_query(F.data == "donate_cancel_invoice")
 async def cancel_donate_invoice(callback: CallbackQuery, state: FSMContext):
     lang = get_lang(callback.from_user)
-    data = await state.get_data()
     await state.set_state(Donate.choosing_currency)
     await callback.message.edit_text(
         tr(lang, "donate_currency"),


### PR DESCRIPTION
## Summary
- remove unused state data fetch in cancel_donate_invoice

## Testing
- `python -m py_compile modules/ui_membership/handlers.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b57763d040832a997473ee26f3b090