### PR TITLE
Localize cancel button in donation invoice

### DIFF
--- a/modules/common/i18n.py
+++ b/modules/common/i18n.py
@@ -24,6 +24,7 @@ BUTTONS = {
 
     "btn_see_chat": "SEE YOU MY CHAT💬",
     "btn_back": "⬅️ Back",
+    "btn_cancel": "❌ Cancel",
     "btn_pay_vip": "💳 Pay VIP",
     "btn_pay_chat": "💳 Pay Chat",
     "reply_placeholder": "Choose an option below:",

--- a/modules/ui_membership/keyboards.py
+++ b/modules/ui_membership/keyboards.py
@@ -88,7 +88,7 @@ def donate_invoice_keyboard(lang, url: str):
     return InlineKeyboardMarkup(
         inline_keyboard=[
             [InlineKeyboardButton(text="\U0001F4B3 Pay", url=url)],
-            [InlineKeyboardButton(text="\u274C Cancel", callback_data="donate_cancel_invoice")]
+            [InlineKeyboardButton(text=tr(lang, "btn_cancel"), callback_data="donate_cancel_invoice")]
         ]
     )
 


### PR DESCRIPTION
## Summary
- translate cancel button in donation invoice keyboard
- register `btn_cancel` in shared i18n dictionary

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b577728ea4832abcdbbc2906f935de