### PR TITLE
Avoid overriding button translations and drop unused keys

### DIFF
--- a/modules/common/i18n.py
+++ b/modules/common/i18n.py
@@ -21,16 +21,15 @@ BUTTONS = {
     "btn_vip": "VIP CLUB 🔞 – 19 $",
     "btn_chat": "SEE YOU СHAT 💬",
     "btn_donate": "DONATE 🎁",
-
-    "btn_see_chat": "SEE YOU MY CHAT💬",
     "btn_back": "⬅️ Back",
     "btn_cancel": "❌ Cancel",
-    "btn_pay_vip": "💳 Pay VIP",
-    "btn_pay_chat": "💳 Pay Chat",
+    "btn_pay": "💳 Pay",
     "reply_placeholder": "Choose an option below:",
 }
 for lang in ("ru", "en", "es"):
-    L10N.setdefault(lang, {}).update(BUTTONS)
+    lang_dict = L10N.setdefault(lang, {})
+    for key, value in BUTTONS.items():
+        lang_dict.setdefault(key, value)
 
 
 def tr(lang: str, key: str, **kwargs) -> str:


### PR DESCRIPTION
## Summary
- prevent default buttons from clobbering locale JSON translations
- remove unused button constants
- add default fallback for `btn_pay`

## Testing
- `python -m py_compile modules/common/i18n.py modules/ui_membership/keyboards.py`


------
https://chatgpt.com/codex/tasks/task_e_68b687c571f0832abb786bebfc88131b