### PR TITLE
Persist VIP invoice records

### DIFF
--- a/modules/payments/handlers.py
+++ b/modules/payments/handlers.py
@@ -12,6 +12,7 @@ from modules.constants.currencies import CURRENCIES
 from modules.ui_membership.chat_keyboards import chat_currency_kb
 from modules.ui_membership.keyboards import vip_currency_kb
 from shared.utils.lang import get_lang
+from shared.db.repo import delete_pending_invoice
 
 
 log = logging.getLogger("juicyfox.payments.handlers")
@@ -27,6 +28,7 @@ async def cancel_payment(callback: CallbackQuery, state: FSMContext) -> None:
     plan_name = data.get("plan_name")
     price = data.get("price")
     period = data.get("period")
+    invoice_id = data.get("invoice_id")
 
     log.debug("Retrieved plan_name from state: %s", plan_name)
 
@@ -65,4 +67,7 @@ async def cancel_payment(callback: CallbackQuery, state: FSMContext) -> None:
 
     # Replace the invoice with the original tariff description and currency menu
     await callback.message.edit_text(desc, reply_markup=kb)
-
+    if invoice_id:
+        await delete_pending_invoice(invoice_id)
+        data.pop("invoice_id", None)
+        await state.set_data(data)

--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -17,6 +17,7 @@ from modules.constants.currencies import CURRENCIES
 from modules.constants.prices import VIP_PRICE_USD
 from modules.constants.paths import START_PHOTO
 from modules.payments import create_invoice
+from shared.db.repo import save_pending_invoice
 from shared.utils.lang import get_lang
 
 log = logging.getLogger("juicyfox.ui_membership.handlers")
@@ -157,6 +158,10 @@ async def pay_vip(callback: CallbackQuery, state: FSMContext) -> None:
         meta=_build_meta(callback.from_user.id, "vip_30d", currency),
         asset=currency,
     )
+    invoice_id = inv.get("invoice_id") if isinstance(inv, dict) else None
+    if invoice_id:
+        await state.update_data(invoice_id=invoice_id, currency=currency, plan_code="vip_30d")
+        await save_pending_invoice(callback.from_user.id, invoice_id, "vip_30d", currency)
     url = _invoice_url(inv)
     if url:
         await callback.message.edit_text(
@@ -165,7 +170,6 @@ async def pay_vip(callback: CallbackQuery, state: FSMContext) -> None:
         )
     else:
         await callback.message.edit_text(tr(lang, "inv_err"))
-    await state.clear()
 
 
 @router.callback_query(F.data.startswith("vipay:"))
@@ -199,6 +203,10 @@ async def vipay_currency(callback: CallbackQuery, state: FSMContext) -> None:
         meta=_build_meta(callback.from_user.id, "vip_30d", cur),
         asset=cur,
     )
+    invoice_id = inv.get("invoice_id") if isinstance(inv, dict) else None
+    if invoice_id:
+        await state.update_data(invoice_id=invoice_id, currency=cur, plan_code="vip_30d")
+        await save_pending_invoice(callback.from_user.id, invoice_id, "vip_30d", cur)
     url = _invoice_url(inv)
     if url:
         await callback.message.edit_text(
@@ -207,7 +215,6 @@ async def vipay_currency(callback: CallbackQuery, state: FSMContext) -> None:
         )
     else:
         await callback.message.edit_text(tr(lang, "inv_err"))
-    await state.clear()
 
 
 


### PR DESCRIPTION
## Summary
- store VIP invoice details and currency in FSM and DB
- keep invoice data until payment or cancellation
- clean up pending invoice records when user cancels

## Testing
- `pytest`
- `python -m py_compile modules/ui_membership/handlers.py modules/payments/handlers.py shared/db/repo.py`


------
https://chatgpt.com/codex/tasks/task_e_68b68b735e6c832a880a04194e6f2785