### PR TITLE
Restore currency choice after invoice cancellation

### DIFF
--- a/modules/payments/handlers.py
+++ b/modules/payments/handlers.py
@@ -6,7 +6,6 @@ from aiogram import F, Router
 from aiogram.fsm.context import FSMContext
 from aiogram.types import CallbackQuery
 from modules.common.i18n import tr
-from modules.constants.prices import CHAT_PRICES_USD
 from modules.ui_membership.chat_keyboards import chat_currency_kb
 from modules.ui_membership.keyboards import vip_currency_kb
 from shared.utils.lang import get_lang
@@ -29,17 +28,22 @@ async def cancel_payment(callback: CallbackQuery, state: FSMContext) -> None:
 
     await delete_active_invoice(callback.from_user.id)
     plan_code = invoice["plan_code"]
+    plan_callback = invoice.get("plan_callback") or ""
 
-    if plan_code.startswith("vip"):
+    if plan_callback.startswith("vipay") or plan_code.startswith("vip"):
         desc = tr(lang, "vip_club_description")
         kb = vip_currency_kb(lang)
     else:
-        amount = CHAT_PRICES_USD.get(plan_code)
-        if amount is None:
-            await callback.answer(tr(lang, "nothing_cancel"), show_alert=True)
-            return
-        desc = tr(lang, "choose_cur", amount=amount)
+        desc = tr(lang, "choose_cur", amount=invoice.get("price"))
         kb = chat_currency_kb(plan_code, lang)
 
     await state.clear()
+    await state.update_data(
+        plan_name=invoice.get("plan_name"),
+        price=invoice.get("price"),
+        period=invoice.get("period"),
+        plan_callback=plan_callback,
+        plan_code=plan_code,
+    )
+
     await callback.message.edit_text(desc, reply_markup=kb)

--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -161,7 +161,16 @@ async def pay_vip(callback: CallbackQuery, state: FSMContext) -> None:
     invoice_id = inv.get("invoice_id") if isinstance(inv, dict) else None
     if invoice_id:
         await state.update_data(invoice_id=invoice_id, currency=currency, plan_code="vip_30d")
-        await save_pending_invoice(callback.from_user.id, invoice_id, "vip_30d", currency)
+        await save_pending_invoice(
+            callback.from_user.id,
+            invoice_id,
+            "vip_30d",
+            currency,
+            "vipay",
+            "VIP CLUB",
+            float(amount),
+            30,
+        )
     url = _invoice_url(inv)
     if url:
         await callback.message.edit_text(
@@ -206,7 +215,16 @@ async def vipay_currency(callback: CallbackQuery, state: FSMContext) -> None:
     invoice_id = inv.get("invoice_id") if isinstance(inv, dict) else None
     if invoice_id:
         await state.update_data(invoice_id=invoice_id, currency=cur, plan_code="vip_30d")
-        await save_pending_invoice(callback.from_user.id, invoice_id, "vip_30d", cur)
+        await save_pending_invoice(
+            callback.from_user.id,
+            invoice_id,
+            "vip_30d",
+            cur,
+            "vipay",
+            "VIP CLUB",
+            float(VIP_PRICE_USD),
+            30,
+        )
     url = _invoice_url(inv)
     if url:
         await callback.message.edit_text(


### PR DESCRIPTION
## Summary
- store plan callback, name, price and period with pending invoices
- repopulate state and show currency keyboard when cancelling an invoice

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b68ee83770832aa99ec7c551b5e02d