### PR TITLE
Store donate invoices and clean up on cancel

### DIFF
--- a/modules/payments/handlers.py
+++ b/modules/payments/handlers.py
@@ -7,7 +7,7 @@ from aiogram.fsm.context import FSMContext
 from aiogram.types import CallbackQuery
 from modules.common.i18n import tr
 from modules.ui_membership.chat_keyboards import chat_currency_kb
-from modules.ui_membership.keyboards import vip_currency_kb
+from modules.ui_membership.keyboards import vip_currency_kb, donate_currency_keyboard
 from shared.utils.lang import get_lang
 from shared.db.repo import get_active_invoice, delete_active_invoice
 
@@ -33,17 +33,32 @@ async def cancel_payment(callback: CallbackQuery, state: FSMContext) -> None:
     if plan_callback.startswith("vipay") or plan_code.startswith("vip"):
         desc = tr(lang, "vip_club_description")
         kb = vip_currency_kb(lang)
+        await state.clear()
+        await state.update_data(
+            plan_name=invoice.get("plan_name"),
+            price=invoice.get("price"),
+            period=invoice.get("period"),
+            plan_callback=plan_callback,
+            plan_code=plan_code,
+        )
+    elif plan_callback == "donate" or plan_code == "donation":
+        from modules.ui_membership.handlers import Donate
+
+        desc = tr(lang, "donate_currency")
+        kb = donate_currency_keyboard(lang)
+        await state.clear()
+        await state.update_data(amount=invoice.get("price"))
+        await state.set_state(Donate.choosing_currency)
     else:
         desc = tr(lang, "choose_cur", amount=invoice.get("price"))
         kb = chat_currency_kb(plan_code, lang)
-
-    await state.clear()
-    await state.update_data(
-        plan_name=invoice.get("plan_name"),
-        price=invoice.get("price"),
-        period=invoice.get("period"),
-        plan_callback=plan_callback,
-        plan_code=plan_code,
-    )
+        await state.clear()
+        await state.update_data(
+            plan_name=invoice.get("plan_name"),
+            price=invoice.get("price"),
+            period=invoice.get("period"),
+            plan_callback=plan_callback,
+            plan_code=plan_code,
+        )
 
     await callback.message.edit_text(desc, reply_markup=kb)


### PR DESCRIPTION
## Summary
- record donation invoices in the pending invoice table
- remove donation invoices when canceling and restore currency selection
- handle donation flow in generic payment cancellation

## Testing
- `pytest`
- `python -m py_compile modules/ui_membership/handlers.py modules/payments/handlers.py`


------
https://chatgpt.com/codex/tasks/task_e_68b69930ca7c832a8baa234a170181ac