### PR TITLE
Log DB schema migration for pending invoices

### DIFF
--- a/shared/db/repo.py
+++ b/shared/db/repo.py
@@ -13,6 +13,9 @@ log = logging.getLogger("juicyfox.db")
 
 DB_PATH = os.getenv("DB_PATH", "/app/data/juicyfox.sqlite")
 
+# Флаг, чтобы сообщение о миграции схемы выводилось только один раз
+_SCHEMA_LOGGED = False
+
 # PRAGMA действуют на УРОВНЕ СОЕДИНЕНИЯ SQLite.
 # Мы применяем их ровно один раз при открытии каждого соединения (см. _db()).
 _PRAGMAS = [
@@ -100,6 +103,10 @@ async def init_db() -> None:
         for stmt in _SCHEMA:
             await db.execute(stmt)
         await db.commit()
+    global _SCHEMA_LOGGED
+    if not _SCHEMA_LOGGED:
+        log.info("DB schema migrated: pending_invoices ready at %s", DB_PATH)
+        _SCHEMA_LOGGED = True
     log.info("sqlite ready at %s", DB_PATH)
 
 


### PR DESCRIPTION
## Summary
- Log when DB schema migration runs and ensure pending_invoices table is ready
- Ensure migration log outputs the database path only once

## Testing
- `pytest`
- `python - <<'PY'
import asyncio, logging
from shared.db.repo import init_db
logging.basicConfig(level=logging.INFO)
async def main():
    await init_db()
    await init_db()
asyncio.run(main())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b69936c618832aadba3d2b03e50c34