### PR TITLE
Remove redundant schema migration log

### DIFF
--- a/shared/db/repo.py
+++ b/shared/db/repo.py
@@ -137,8 +137,6 @@ async def init_db() -> None:
         log.info("DB schema migrated: pending_invoices ready at %s", DB_PATH)
         _SCHEMA_LOGGED = True
 
-    log.info("DB schema migrated: pending_invoices ready")
-
     log.info("sqlite ready at %s", DB_PATH)
 
 


### PR DESCRIPTION
## Summary
- remove duplicate 'pending_invoices ready' log so schema migration message appears only once

## Testing
- `python -m py_compile shared/db/repo.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6a08841c4832abf698be45c8d34c9