### PR TITLE
Simplify pending_invoices schema migration

### DIFF
--- a/shared/db/repo.py
+++ b/shared/db/repo.py
@@ -103,41 +103,21 @@ async def init_db() -> None:
         for stmt in _SCHEMA:
             await db.execute(stmt)
         cur = await db.execute("PRAGMA table_info(pending_invoices)")
-        rows = await cur.fetchall()
-        if not rows:
-            await db.execute(
-                """
-                CREATE TABLE pending_invoices (
-                    invoice_id TEXT PRIMARY KEY,
-                    user_id INTEGER NOT NULL,
-                    plan_code TEXT NOT NULL,
-                    currency TEXT NOT NULL,
-                    plan_callback TEXT,
-                    plan_name TEXT,
-                    price REAL,
-                    period INTEGER,
-                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-                );
-                """
-            )
-        else:
-            cols = {r[1] for r in rows}
-            if "plan_callback" not in cols:
-                await db.execute("ALTER TABLE pending_invoices ADD COLUMN plan_callback TEXT")
-            if "plan_name" not in cols:
-                await db.execute("ALTER TABLE pending_invoices ADD COLUMN plan_name TEXT")
-            if "price" not in cols:
-                await db.execute("ALTER TABLE pending_invoices ADD COLUMN price REAL")
-            if "period" not in cols:
-                await db.execute("ALTER TABLE pending_invoices ADD COLUMN period INTEGER")
+        cols = {r[1] for r in await cur.fetchall()}
+        if "plan_callback" not in cols:
+            await db.execute("ALTER TABLE pending_invoices ADD COLUMN plan_callback TEXT")
+        if "plan_name" not in cols:
+            await db.execute("ALTER TABLE pending_invoices ADD COLUMN plan_name TEXT")
+        if "price" not in cols:
+            await db.execute("ALTER TABLE pending_invoices ADD COLUMN price REAL")
+        if "period" not in cols:
+            await db.execute("ALTER TABLE pending_invoices ADD COLUMN period INTEGER")
         await db.commit()
 
     global _SCHEMA_LOGGED
     if not _SCHEMA_LOGGED:
-        log.info("DB schema migrated: pending_invoices ready at %s", DB_PATH)
+        log.info("DB schema migrated: pending_invoices ready")
         _SCHEMA_LOGGED = True
-
-    log.info("DB schema migrated: pending_invoices ready")
 
     log.info("sqlite ready at %s", DB_PATH)
 


### PR DESCRIPTION
## Summary
- streamline `init_db` pending invoice migration by removing table recreation
- add conditional column additions for plan callback info
- log `pending_invoices ready` only once

## Testing
- `pytest`
- `python - <<'PY'
import asyncio, logging
from shared.db.repo import init_db
logging.basicConfig(level=logging.INFO)
asyncio.run(init_db())
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b6a14b38c4832a9dea68d86cd9e46f