### PR TITLE
Handle donation cancel flow more consistently

### DIFF
--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -17,7 +17,7 @@ from modules.constants.currencies import CURRENCIES
 from modules.constants.prices import VIP_PRICE_USD
 from modules.constants.paths import START_PHOTO
 from modules.payments import create_invoice
-from shared.db.repo import save_pending_invoice, delete_active_invoice
+from shared.db.repo import save_pending_invoice, get_active_invoice, delete_pending_invoice
 from shared.utils.lang import get_lang
 
 log = logging.getLogger("juicyfox.ui_membership.handlers")
@@ -325,27 +325,41 @@ async def donate_set_currency(cq: CallbackQuery, state: FSMContext) -> None:
 
 @router.callback_query(F.data == "donate_cancel_invoice")
 async def cancel_donate_invoice(callback: CallbackQuery, state: FSMContext):
-    """Cancel invoice and show the main menu."""
+    """Cancel donation invoice and return to currency selection."""
     lang = get_lang(callback.from_user)
-    await delete_active_invoice(callback.from_user.id)
+    invoice = await get_active_invoice(callback.from_user.id)
+    log.debug("Active invoice for user %s: %s", callback.from_user.id, invoice)
+    if not invoice:
+        await callback.answer(tr(lang, "nothing_cancel"), show_alert=True)
+        return
+    await delete_pending_invoice(invoice["invoice_id"])
     await state.clear()
+    await state.update_data(amount=invoice.get("price"))
+    await state.set_state(Donate.choosing_currency)
     await callback.answer(tr(lang, "donate_cancel"))
     await callback.message.edit_text(
-        tr(lang, "choose_action"),
-        reply_markup=main_menu_kb(lang),
+        tr(lang, "donate_currency"),
+        reply_markup=donate_currency_keyboard(lang),
     )
 
 
 @router.callback_query(F.data == "donate_cancel")
 async def cancel_donate(callback: CallbackQuery, state: FSMContext) -> None:
-    """Handle external donate cancel actions and return to main menu."""
+    """Handle external donate cancel actions and return to currency selection."""
     lang = get_lang(callback.from_user)
-    await delete_active_invoice(callback.from_user.id)
+    invoice = await get_active_invoice(callback.from_user.id)
+    log.debug("Active invoice for user %s: %s", callback.from_user.id, invoice)
+    if not invoice:
+        await callback.answer(tr(lang, "nothing_cancel"), show_alert=True)
+        return
+    await delete_pending_invoice(invoice["invoice_id"])
     await state.clear()
+    await state.update_data(amount=invoice.get("price"))
+    await state.set_state(Donate.choosing_currency)
     await callback.answer(tr(lang, "donate_cancel"))
     await callback.message.edit_text(
-        tr(lang, "choose_action"),
-        reply_markup=main_menu_kb(lang),
+        tr(lang, "donate_currency"),
+        reply_markup=donate_currency_keyboard(lang),
     )
 
 


### PR DESCRIPTION
## Summary
- ensure both donate cancel handlers delete the pending invoice and return to currency selection
- redirect users to the currency chooser instead of the main menu after cancelling a donation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6a3df6b38832a891b79dcb7dd2ecb