### PR TITLE
Remove obsolete delete_active_invoice usage

### DIFF
--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -18,13 +18,10 @@ from modules.constants.prices import VIP_PRICE_USD
 from modules.constants.paths import START_PHOTO
 from modules.payments import create_invoice
 
-from shared.db.repo import save_pending_invoice, get_active_invoice, delete_pending_invoice
-
 from shared.db.repo import (
     save_pending_invoice,
     get_active_invoice,
     delete_pending_invoice,
-    delete_active_invoice,
 )
 
 from shared.utils.lang import get_lang

--- a/shared/db/repo.py
+++ b/shared/db/repo.py
@@ -359,11 +359,6 @@ async def get_active_invoice(user_id: int) -> Optional[Dict[str, Any]]:
         return None
 
 
-async def delete_active_invoice(user_id: int) -> None:
-    async with _db() as db:
-        await db.execute("DELETE FROM pending_invoices WHERE user_id=?", (user_id,))
-        await db.commit()
-
 async def log_payment_event(event: Dict[str, Any]) -> None:
     """
     event: dict из normalize_webhook(...), поля: provider, invoice_id, status, amount, currency, meta


### PR DESCRIPTION
## Summary
- remove `delete_active_invoice` helper from repo
- clean up UI membership handlers to rely on `delete_pending_invoice`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6b2928140832ab22d537e8d0b940d