### PR TITLE
Remove duplicate invoice check in donation cancellation handler

### DIFF
--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -340,9 +340,6 @@ async def cancel_donate_invoice(callback: CallbackQuery, state: FSMContext):
         await callback.answer(tr(lang, "nothing_cancel"), show_alert=True)
         return
 
-    if not invoice:
-        await callback.answer(tr(lang, "nothing_cancel"), show_alert=True)
-        return
     fsm_state = await state.get_state()
     deleted_rows = await delete_pending_invoice(invoice["invoice_id"])
     log.info(


### PR DESCRIPTION
## Summary
- drop redundant `if not invoice` block when cancelling donation invoice

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6b54ceec8832a92e4ad7cacb6d20e