### PR TITLE
feat: persist relay users

### DIFF
--- a/alembic/versions/0001_relay_users.py
+++ b/alembic/versions/0001_relay_users.py
@@ -1,0 +1,23 @@
+# fix: add relay_users table
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0001'
+down_revision = None
+branch_labels = depends_on = None
+
+# REGION AI: relay_users table
+def upgrade() -> None:
+    op.create_table('relay_users',
+        sa.Column('user_id', sa.Integer, primary_key=True),
+        sa.Column('username', sa.Text),
+        sa.Column('full_name', sa.Text),
+        sa.Column('last_seen', sa.TIMESTAMP, server_default=sa.text('CURRENT_TIMESTAMP')),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('relay_users')
+# END REGION AI


### PR DESCRIPTION
## Summary
- add `relay_users` table and helpers for upserting and fetching relay users
- persist and lookup relay users when relaying messages
- add migration creating `relay_users` table

## Testing
- `flake8 shared/db/repo.py modules/chat_relay/handlers.py alembic/versions/0001_relay_users.py` *(fails: E302, E501)*
- `python -c "import importlib; importlib.import_module('shared.db.repo')"`
- `python -c "import importlib; importlib.import_module('modules.chat_relay.handlers')"`
- `uvicorn api.webhook:app --port 0` *(fails: Error loading ASGI app)*
- `pytest modules/chat_relay`

------
https://chatgpt.com/codex/tasks/task_e_68b7ffae35e0832aa50543791f0924e7