### PR TITLE
refactor(chat_relay): remove duplicate retry helper

### DIFF
--- a/modules/chat_relay/handlers.py
+++ b/modules/chat_relay/handlers.py
@@ -207,21 +207,6 @@ async def relay_incoming_to_group(msg: Message):
     """
     if not RELAY_GROUP_ID:
         return
-    # REGION AI: retry helper
-    async def _send_with_retry(func, *args, **kwargs):
-        for attempt in range(3):
-            try:
-                await func(*args, **kwargs)
-                return
-            except TelegramNetworkError as e:
-                if attempt == 2:
-                    log.exception("relay to group failed: %s", e)
-                else:
-                    await asyncio.sleep(1)
-            except Exception as e:
-                log.exception("relay to group failed: %s", e)
-                return
-    # END REGION AI
 
     # Игнорируем команды вида "/start", "/help", "/..."
     if msg.text and msg.text.startswith("/"):


### PR DESCRIPTION
## Summary
- remove redundant `_send_with_retry` definition inside `relay_incoming_to_group`
- rely on global `_send_with_retry` helper for message relaying

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b81d9caf68832ab27bef1183e29dc6