### PR TITLE
Simplify relay header formatting

### DIFF
--- a/modules/chat_relay/handlers.py
+++ b/modules/chat_relay/handlers.py
@@ -121,25 +121,35 @@ def _user_stats(uid: int) -> tuple[float, Optional[int]]:
 def _fmt_from(msg: Message) -> str:
     u = msg.from_user
     uid = u.id if u else "unknown"
-    uname = f"@{u.username}" if u and u.username else ""
-    name = f"{u.full_name}" if u else ""
     lang = (u.language_code or "")[:2] if u else ""
     flag = (
         "".join(chr(ord(c.upper()) + 127397) for c in lang)
         if len(lang) == 2
         else ""
     )
-    if lang == "en" and flag:
-        flag = f"{flag} EN"
+    if lang == "en":
+        flag = "🇺🇸 EN"
+
     total, until_ts = _user_stats(uid) if isinstance(uid, int) else (0.0, None)
-    lines = [f"from: {uid}"]
-    second = " ".join(x for x in [name, uname, flag] if x).strip()
-    if second:
-        lines.append(second)
-    lines.append(f"💰 ${total:.2f}")
+
+    parts = [f"from: {uid}"]
+
+    display = (u.full_name or u.username) if u else None
+    if display:
+        parts.append(display)
+
+    if u and u.username:
+        parts.append(f"@{u.username}")
+
+    if flag:
+        parts.append(flag)
+
+    parts.append(f"💰 ${total:.2f}")
+
     if until_ts:
-        lines.append(time.strftime("до %Y-%m-%d", time.localtime(until_ts)))
-    return "\n".join(lines)
+        parts.append(time.strftime("до %Y-%m-%d", time.localtime(until_ts)))
+
+    return " • ".join(parts)
 # END REGION AI
 
 


### PR DESCRIPTION
## Summary
- Redefine `_fmt_from` to build single-line `from` header
- Include optional display name, username, locale flag, balance, and expiry date

## Testing
- `python - <<'PY'
import time
from types import SimpleNamespace
import modules.chat_relay.handlers as h

u1 = SimpleNamespace(id=123456, full_name=None, username=None, language_code=None)
msg1 = SimpleNamespace(from_user=u1)
print(h._fmt_from(msg1))

u2 = SimpleNamespace(id=123456, full_name="Work Out", username=None, language_code="ru")
msg2 = SimpleNamespace(from_user=u2)
print(h._fmt_from(msg2))

u3 = SimpleNamespace(id=123456, full_name="Gar2018", username=None, language_code="en")
msg3 = SimpleNamespace(from_user=u3)
h._user_stats = lambda uid: (15.0, int(time.mktime((2025,9,30,0,0,0,0,0,-1))))
print(h._fmt_from(msg3))
PY`
- `pytest >/tmp/pytest.log 2>&1 ; tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_68b8c2bd3360832aab0f4c3ea2bc7586