### PR TITLE
fix: use send_invoice for Telegram Stars

### DIFF
--- a/modules/payments/handlers.py
+++ b/modules/payments/handlers.py
@@ -84,14 +84,15 @@ async def pay_stars(callback: CallbackQuery, state: FSMContext) -> None:
     plan_code = data.get("plan_code") or "donation"
     purchase = "vip" if plan_code.startswith("vip") else "donate"
     title = data.get("plan_name") or purchase
-    amount = float(data.get("price") or 1.0)
-    await callback.message.answer_invoice(
+    amount = int(data.get("price") or 1)
+    await callback.bot.send_invoice(
+        chat_id=callback.from_user.id,
         title=title,
         description=tr(lang, "choose_cur", amount=amount),
         payload=f"{purchase}:{plan_code}",
         provider_token="",
         currency="XTR",
-        prices=[LabeledPrice(label=title, amount=int(amount * 100))],
+        prices=[LabeledPrice(label=title, amount=amount * 100)],
     )
 
 


### PR DESCRIPTION
## Summary
- fix Telegram Stars payment handler to use `bot.send_invoice`

## Testing
- `ruff check modules/payments/handlers.py`
- `python - <<'PY'\nimport importlib\nimportlib.import_module('modules.payments.handlers')\nprint('import ok')\nPY`
- `uvicorn api.webhook:app --port 0` *(fails: Attribute "app" not found in module "api.webhook")*
- `pytest modules/payments -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8d3fc6bb0832a835381893b19162a