### PR TITLE
Localize Telegram Stars payments and thank donors

### DIFF
--- a/modules/payments/handlers.py
+++ b/modules/payments/handlers.py
@@ -87,7 +87,7 @@ async def pay_stars(callback: CallbackQuery, state: FSMContext) -> None:
     amount = float(data.get("price") or 1.0)
     await callback.message.answer_invoice(
         title=title,
-        description=tr(lang, "choose_cur", amount=amount),
+        description=tr(lang, "stars_payment_desc"),
         payload=f"{purchase}:{plan_code}",
         provider_token="",
         currency="XTR",
@@ -104,5 +104,6 @@ async def stars_success(message: Message) -> None:
         await grant(message.from_user.id, plan_code or "vip_30d", bot=message.bot)
         await message.answer(tr(lang, "pay_conf"))
     else:
-        await message.answer(tr(lang, "donate_intro_1"))
+        amount = message.successful_payment.total_amount / 100
+        await message.answer(tr(lang, "donate_thanks", amount=amount))
 # END REGION AI


### PR DESCRIPTION
## Summary
- Localize Telegram Stars invoice description using `stars_payment_desc`
- Thank donors with localized amount after successful Telegram Stars payment

## Testing
- `ruff check modules/payments/handlers.py`
- `python -c "import modules.payments.handlers"`
- `uvicorn api.webhook:app --port 0` *(fails: Attribute "app" not found in module "api.webhook")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8d81a1d38832a83dc37ba2276a3fe