### PR TITLE
fix: donate callback split and VIP stars detection

### DIFF
--- a/modules/payments/handlers.py
+++ b/modules/payments/handlers.py
@@ -84,8 +84,13 @@ async def cancel_payment(callback: CallbackQuery, state: FSMContext) -> None:
 async def pay_stars(callback: CallbackQuery, state: FSMContext) -> None:
     lang = get_lang(callback.from_user)
     data = await state.get_data()
-    plan_code = data.get("plan_code") or "donation"
-    purchase = "vip" if plan_code.startswith("vip") else "donate"
+    plan_code = data.get("plan_code") or ""
+    plan_callback = data.get("plan_callback") or ""
+    if plan_callback == "vip" or (plan_code and plan_code.startswith("vip")):
+        purchase = "vip"
+    else:
+        purchase = "donate"
+    plan_code = plan_code or "donation"
     title = data.get("plan_name") or purchase
     amount = float(data.get("price") or 1.0)
     # REGION AI: stars invoice prompt

--- a/modules/ui_membership/keyboards.py
+++ b/modules/ui_membership/keyboards.py
@@ -41,8 +41,9 @@ def currency_menu(lang: str | None, prefix: str) -> InlineKeyboardMarkup:
     kb = vip_currency_kb(lang)
     for row in kb.inline_keyboard[:-1]:
         for btn in row:
-            if btn.callback_data and ":" in btn.callback_data:
-                code = btn.callback_data.split(":", 1)[1]
+            if btn.callback_data:
+                data = btn.callback_data
+                code = data.split(":", 1)[1] if ":" in data else data
                 btn.callback_data = f"{prefix}{code}"
     back_btn = kb.inline_keyboard[-1][0]
     back_btn.callback_data = "donate:back" if prefix.startswith("donate") else "ui:back"
@@ -78,9 +79,13 @@ def donate_keyboard(lang: str | None = None) -> InlineKeyboardMarkup:
 
 def donate_currency_keyboard(lang: str | None = None) -> InlineKeyboardMarkup:
     kb = vip_currency_kb(lang)
+    # REGION AI: donate callback split
     for row in kb.inline_keyboard[:-1]:
         for btn in row:
-            btn.callback_data = f"donate${btn.callback_data.split(':', 1)[1]}"
+            data = btn.callback_data or ""
+            code = data.split(":", 1)[1] if ":" in data else data
+            btn.callback_data = f"donate${code}"
+    # END REGION AI
     kb.inline_keyboard[-1][0] = InlineKeyboardButton(
         text=tr(lang or "en", "btn_back"), callback_data="donate_back"
     )


### PR DESCRIPTION
## Summary
- handle donate currency callbacks without IndexError
- ensure VIP star purchases classified as vip

## Testing
- `ruff check modules/ui_membership/keyboards.py modules/payments/handlers.py`
- `python - <<'PY'
import importlib
importlib.import_module('modules.ui_membership.keyboards')
print('ok')
PY`
- `python - <<'PY'
import importlib
importlib.import_module('modules.payments.handlers')
print('ok')
PY`
- `uvicorn api.webhook:app --port 0` *(fails: Attribute "app" not found in module "api.webhook".)*
- `pytest modules/ui_membership/keyboards.py modules/payments/handlers.py` *(errors: ModuleNotFoundError: No module named 'modules')*


------
https://chatgpt.com/codex/tasks/task_e_68b8dd297bc8832a8e3306e564782ae7