### PR TITLE
fix: handle star donations and VIP classification

### DIFF
--- a/modules/payments/handlers.py
+++ b/modules/payments/handlers.py
@@ -88,9 +88,11 @@ async def pay_stars(callback: CallbackQuery, state: FSMContext) -> None:
     plan_callback = data.get("plan_callback") or ""
     if plan_callback == "vip" or (plan_code and plan_code.startswith("vip")):
         purchase = "vip"
+        plan_code = plan_code or "vip_30d"
+        await state.update_data(plan_code=plan_code, plan_callback="vip")
     else:
         purchase = "donate"
-    plan_code = plan_code or "donation"
+        plan_code = plan_code or "donation"
     title = data.get("plan_name") or purchase
     amount = float(data.get("price") or 1.0)
     # REGION AI: stars invoice prompt

--- a/modules/ui_membership/keyboards.py
+++ b/modules/ui_membership/keyboards.py
@@ -83,6 +83,8 @@ def donate_currency_keyboard(lang: str | None = None) -> InlineKeyboardMarkup:
     for row in kb.inline_keyboard[:-1]:
         for btn in row:
             data = btn.callback_data or ""
+            if data == "pay_stars":
+                continue
             code = data.split(":", 1)[1] if ":" in data else data
             btn.callback_data = f"donate${code}"
     # END REGION AI


### PR DESCRIPTION
## Summary
- prevent IndexError in donate currency keyboard and preserve Stars callback
- split VIP and donate logic for Stars payments

## Testing
- `ruff check modules/payments/handlers.py modules/ui_membership/keyboards.py`
- `python -c "import importlib; importlib.import_module('modules.payments.handlers')"`
- `python - <<'PY'
import importlib
importlib.import_module('modules.ui_membership.keyboards')
PY`
- `uvicorn api.webhook:app --port 0` *(fails: Attribute "app" not found in module "api.webhook")*
- `pytest modules/payments/handlers.py modules/ui_membership/keyboards.py` *(fails: ModuleNotFoundError: No module named 'modules')*

------
https://chatgpt.com/codex/tasks/task_e_68b8e05e8c98832a8c8fccea68da1268