### PR TITLE
feat: enable Telegram Stars payments for chat plans

### DIFF
--- a/modules/ui_membership/chat_keyboards.py
+++ b/modules/ui_membership/chat_keyboards.py
@@ -19,9 +19,13 @@ def chat_tariffs_kb(lang: str) -> InlineKeyboardMarkup:
 
 def chat_currency_kb(plan_code: str, lang: str | None = None) -> InlineKeyboardMarkup:
     """Keyboard for choosing payment currency for chat plans."""
+    # REGION AI: add Stars option
     b = InlineKeyboardBuilder()
+    stars_code = f"{plan_code}d"
+    b.button(text="⭐ Stars", callback_data=f"pay_stars:{stars_code}")
     for title, code in CURRENCIES:
         b.button(text=title, callback_data=f"paymem:{plan_code}:{code}")
     b.button(text=tr(lang or "en", "btn_back"), callback_data="ui:back")
-    b.adjust(2, 2, 2, 2, 1)
+    b.adjust(1, 2, 2, 2, 2, 1)
     return b.as_markup()
+    # END REGION AI


### PR DESCRIPTION
## Summary
- allow paying SEE YOU CHAT tariffs with Telegram Stars
- add Stars option in chat currency selection

## Testing
- `ruff check modules/payments/handlers.py modules/ui_membership/chat_keyboards.py`
- `python - <<'PY'
import importlib
importlib.import_module('modules.payments.handlers')
importlib.import_module('modules.ui_membership.chat_keyboards')
print('imports passed')
PY`
- `uvicorn api.webhook:app --port 0` *(fails: Attribute "app" not found)*
- `pytest modules/payments/handlers.py modules/ui_membership/chat_keyboards.py` *(fails: ModuleNotFoundError: No module named 'modules')*


------
https://chatgpt.com/codex/tasks/task_e_68b970c219a0832a9b91731d2d7844b9