### PR TITLE
fix: remove duplicate Telegram Stars invoice message

### DIFF
--- a/modules/payments/handlers.py
+++ b/modules/payments/handlers.py
@@ -119,7 +119,6 @@ async def pay_stars(callback: CallbackQuery, state: FSMContext) -> None:
         purchase = "vip" if plan_callback == "vip" or plan_code.startswith("vip") else "donate"
         title = data.get("plan_name") or ("VIP CLUB - 19$" if purchase == "vip" else purchase)
         stars = int(data.get("stars") or 100)
-    await callback.message.answer(tr(lang, "choose_cur_stars", amount=stars))
     await callback.message.answer_invoice(
         title=title,
         description=tr(lang, "stars_payment_desc"),


### PR DESCRIPTION
## Summary
- remove extra Stars payment hint before issuing invoice

## Testing
- `ruff check modules/payments/handlers.py`
- `python - <<'PY'
import importlib
importlib.import_module('modules.payments.handlers')
print('import ok')
PY`
- `timeout 5 uvicorn api.webhook:app --port 0` *(fails: Attribute "app" not found in module "api.webhook")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b97764fa4c832ab24392a8f8ed472f