### PR TITLE
feat: add group-to-user lookup

### DIFF
--- a/shared/db/repo.py
+++ b/shared/db/repo.py
@@ -510,3 +510,18 @@ async def get_group_for_user(user_id: int) -> Optional[int]:
             )
         ).fetchone()
     return int(row[0]) if row else None
+
+
+# feat: reverse lookup user by group
+# REGION AI: get user by group
+async def get_user_by_group(group_id: int) -> Optional[int]:
+    sql = "SELECT user_id FROM users WHERE group_id=? AND status='active'"
+    async with _db() as db:
+        row = await (await db.execute(sql, (group_id,))).fetchone()
+    if row:
+        user_id = int(row[0])
+        log.info("get_user_by_group found: group_id=%s user_id=%s", group_id, user_id)
+        return user_id
+    log.warning("get_user_by_group not found: group_id=%s", group_id)
+    return None
+# END REGION AI


### PR DESCRIPTION
## Summary
- add async get_user_by_group to locate users by personal group id

## Testing
- `ruff check shared/db/repo.py`
- `python -c "import importlib; importlib.import_module('shared.db.repo')"`
- `uvicorn api.webhook:app --port 0` *(fails: Attribute "app" not found in module "api.webhook")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb13c0abcc832aa6f600604fabf697