### PR TITLE
feat: add groupid command

### DIFF
--- a/modules/chat_relay/handlers.py
+++ b/modules/chat_relay/handlers.py
@@ -524,3 +524,12 @@ async def link_user_to_group(message: Message, command: CommandObject) -> None:
             pass
     await message.reply(_link_text(lang, "ok", user_id, group_id))
 # END REGION AI
+
+# REGION AI: groupid command
+@router.message(Command("groupid"))
+async def cmd_groupid(message: Message) -> None:
+    if message.chat.type not in {"group", "supergroup"}:
+        return
+    await message.reply(f"Group ID: {message.chat.id}")
+    log.info("cmd_groupid: group_id=%s title=%s", message.chat.id, message.chat.title)
+# END REGION AI


### PR DESCRIPTION
## Summary
- add /groupid handler to log and reply with chat ID in groups

## Testing
- `ruff check modules/chat_relay/handlers.py`
- `python -c "import importlib; importlib.import_module('modules.chat_relay.handlers')"`
- `uvicorn api.webhook:app --port 0` *(fails: command not found)*
- `pytest modules/chat_relay`


------
https://chatgpt.com/codex/tasks/task_e_68bc02748d90832ab2a07aa2a1e867bc