### PR TITLE
fix: ensure /groupid works without DB binding

### DIFF
--- a/modules/chat_relay/handlers.py
+++ b/modules/chat_relay/handlers.py
@@ -323,7 +323,10 @@ async def _copy_and_log(msg: Message, user_id: int) -> None:
     await _repo.log_message(user_id, "out", log_rec)
 
 
-@router.message(F.chat.type.in_({"group", "supergroup"}))
+@router.message(
+    F.chat.type.in_({"group", "supergroup"}),
+    ~F.text.startswith("/"),
+)
 async def relay_from_group(msg: Message) -> None:
     group_id = msg.chat.id
     user_id: Optional[int] = None


### PR DESCRIPTION
## Summary
- ensure group relay ignores slash commands so /groupid bypasses DB checks

## Testing
- `ruff check modules/chat_relay/handlers.py`
- `python - <<'PY'
import importlib
importlib.import_module('modules.chat_relay.handlers')
PY`
- `uvicorn api.webhook:app --port 0` *(fails: Attribute "app" not found)*
- `pytest modules/chat_relay -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc40118d58832ab1397d9a52c8a45e