### PR TITLE
fix: handle missing channel in posting

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -79,6 +79,7 @@
   "choose_minute": "Choose minute",
   "post_number": "Post #{num:03d}",
   "post_channel_not_selected": "Error: channel not selected.",
+  "post_channel_not_specified": "Error: channel not specified for publication.",
   "media_added": "Media added",
   "text_saved": "Text saved",
   "history_usage": "⚠️ Use /history <user_id> [limit]",

--- a/locales/es.json
+++ b/locales/es.json
@@ -79,6 +79,7 @@
   "choose_minute": "Elige minuto",
   "post_number": "Publicación #{num:03d}",
   "post_channel_not_selected": "Error: canal no seleccionado.",
+  "post_channel_not_specified": "Error: no se especificó el canal para la publicación.",
   "media_added": "Medio agregado",
   "text_saved": "Texto guardado",
   "history_usage": "⚠️ Usa /history <user_id> [limit]",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -80,6 +80,7 @@
   "btn_cancel": "❌ Cancel",
   "post_number": "Пост №{num:03d}",
   "post_channel_not_selected": "Ошибка: не выбран канал.",
+  "post_channel_not_specified": "Ошибка: не указан канал для публикации.",
   "media_added": "Медиа добавлено",
   "text_saved": "Текст сохранён",
   "history_usage": "⚠️ Используй /history <user_id> [limit]",


### PR DESCRIPTION
## Summary
- handle missing `channel` in posting plan
- localize channel missing error for RU/EN/ES

## Testing
- `ruff check modules/posting/handlers.py` *(fails: E701, E702, E722)*
- `python -c "import importlib; importlib.import_module('modules.posting.handlers')"`
- `uvicorn api.webhook:app --port 0` *(exit 1)*
- `pytest modules/posting/handlers.py` *(ModuleNotFoundError: No module named 'modules')*

------
https://chatgpt.com/codex/tasks/task_e_68c04a0d4208832a813871c63379f1e7