### PR TITLE
fix: inline free channel link

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -8,7 +8,7 @@
   "tip_menu": "🛍 Tip Menu",
   "activate_chat": "See you my chaT 💬",
   "life_link": "👀 My channel: {url}",
-  "my_channel": "👀 My free channel: {link}",
+  "my_channel": "👀 My free channel: [JuicyFox Official Life](https://t.me/JuisyFoxOfficialLife)",
   "choose_action": "Choose an action below:",
   "choose_post_plan": "Choose action",
   "choose_cur": "Choose payment method: {amount}⭐",

--- a/locales/es.json
+++ b/locales/es.json
@@ -8,7 +8,7 @@
   "tip_menu": "🛍 Menú de propinas",
   "activate_chat": "See you my chaT 💬",
   "life_link": "👀 Mi canal: {url}",
-  "my_channel": "👀 Mi canal gratuito: {link}",
+  "my_channel": "👀 Mi canal gratuito: [JuicyFox Official Life](https://t.me/JuisyFoxOfficialLife)",
   "choose_action": "Elige una acción abajo:",
   "choose_post_plan": "Elige acción",
   "choose_cur": "Elige método de pago: {amount}⭐",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -8,7 +8,7 @@
   "tip_menu": "🛍 Tip Menu",
   "activate_chat": "See you my chaT 💬",
   "life_link": "👀 Мой канал: {url}",
-  "my_channel": "👀 Мой бесплатный канал: {link}",
+  "my_channel": "👀 Мой бесплатный канал: [JuicyFox Official Life](https://t.me/JuisyFoxOfficialLife)",
   "choose_action": "Выбери действие ниже:",
   "choose_post_plan": "Выберите действие",
   "choose_cur": "Выбери способ оплаты: {amount}⭐",

--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -78,10 +78,14 @@ async def cmd_start(message: Message, state: FSMContext) -> None:
         caption=tr(lang, "menu", name=message.from_user.first_name),
     )
     if LIFE_URL:
+        # REGION AI: inline link with no preview
         await message.answer(
-            tr(lang, "my_channel", link=LIFE_URL),
+            tr(lang, "my_channel"),
             reply_markup=reply_menu(lang),
+            parse_mode="Markdown",
+            disable_web_page_preview=True,
         )
+        # END REGION AI
     else:
         await message.answer(
             tr(lang, "choose_action"),
@@ -513,7 +517,14 @@ async def life_link(cq: CallbackQuery):
     lang = get_lang(cq.from_user)
     kb = InlineKeyboardBuilder()
     kb.button(text=tr(lang, "btn_back"), callback_data="ui:back")
-    await cq.message.edit_text(tr(lang, "life", my_channel=LIFE_URL), reply_markup=kb.as_markup())
+    # REGION AI: inline link with no preview
+    await cq.message.edit_text(
+        tr(lang, "life", my_channel=tr(lang, "my_channel")),
+        reply_markup=kb.as_markup(),
+        parse_mode="Markdown",
+        disable_web_page_preview=True,
+    )
+    # END REGION AI
 
 @router.message(
     lambda m: _norm(m.text) == _norm(tr(get_lang(m.from_user), "btn_chat"))


### PR DESCRIPTION
## Summary
- embed free channel link directly in locales
- prevent Telegram preview for welcome and life link messages

## Testing
- `ruff check modules/ui_membership/handlers.py locales/ru.json locales/en.json locales/es.json`
- `python - <<'PY'` (import modules.ui_membership.handlers)
- `uvicorn api.webhook:app --port 0` *(fails: Attribute "app" not found)*
- `pytest modules/ui_membership -q`

------
https://chatgpt.com/codex/tasks/task_e_68c54118210c832ab9a1115869c0fdd7