### PR TITLE
fix: add default life channel URL

### DIFF
--- a/shared/config/env.py
+++ b/shared/config/env.py
@@ -195,7 +195,15 @@ def load_config(bot_id: Optional[str] = None) -> Config:
         loglevel=_get_alias(env, "LOGLEVEL", default=yaml_data.get("loglevel", "INFO")),
         model_name=_get_alias(env, "MODEL_NAME", default=yaml_data.get("model_name", "Juicy Fox")),
         vip_url=_get_alias(env, "VIP_URL", default=yaml_data.get("vip_url")),
-        life_url=_get_alias(env, "LIFE_URL", "LIVE_URL", default=yaml_data.get("life_url")),
+        # REGION AI: life_url fallback
+        # fix: provide default life channel URL
+        life_url=_get_alias(
+            env,
+            "LIFE_URL",
+            "LIVE_URL",
+            default=yaml_data.get("life_url") or "https://t.me/JuisyFoxOfficialLife",
+        ),
+        # END REGION AI
         vip_price_usd=float(_get_alias(env, "VIP_PRICE_USD", "VIP_30D_USD", default=yaml_data.get("vip_price_usd", 35))),
         chat_price_usd=float(_get_alias(env, "CHAT_PRICE_USD", "CHAT_30D_USD", default=yaml_data.get("chat_price_usd", 15))),
         chat_group_id=int(_get_alias(env, "CHAT_GROUP_ID", default=_yaml_int("chat_group_id", 0) or 0) or 0),


### PR DESCRIPTION
## Summary
- add fallback for life channel URL when env vars missing

## Testing
- `ruff check shared/config/env.py`
- `TELEGRAM_TOKEN=dummy BOT_ID=test python -c "import importlib; importlib.import_module('shared.config.env')"`
- `TELEGRAM_TOKEN=dummy BOT_ID=test timeout 5 uvicorn api.webhook:app --port 0` *(fails: Attribute "app" not found in module "api.webhook")*
- `TELEGRAM_TOKEN=dummy BOT_ID=test pytest shared/config/env.py`

------
https://chatgpt.com/codex/tasks/task_e_68c70ab465a8832ab3236bc8ba27275d