### PR TITLE
fix: correct life channel URL fallback

### DIFF
--- a/shared/config/env.py
+++ b/shared/config/env.py
@@ -201,7 +201,7 @@ def load_config(bot_id: Optional[str] = None) -> Config:
             env,
             "LIFE_URL",
             "LIVE_URL",
-            default=yaml_data.get("life_url") or "https://t.me/JuisyFoxOfficialLife",
+            default=yaml_data.get("life_url") or "https://t.me/JuicyFoxOfficialLife",
         ),
         # END REGION AI
         vip_price_usd=float(_get_alias(env, "VIP_PRICE_USD", "VIP_30D_USD", default=yaml_data.get("vip_price_usd", 35))),


### PR DESCRIPTION
## Summary
- ensure life channel fallback uses JuicyFoxOfficialLife

## Testing
- `ruff check shared/config/env.py`
- `TELEGRAM_TOKEN=1 python - <<'PY'
import importlib
importlib.import_module('shared.config.env')
print('imported successfully')
PY`
- `TELEGRAM_TOKEN=1 uvicorn api.webhook:app --port 0`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7155c10a0832ab65bc4a07742b3af