### PR TITLE
feat: add life channel promo

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -9,6 +9,7 @@
   "activate_chat": "See you my chaT 💬",
   "life_link": "👀 My channel: {url}",
   "my_channel": "👀 My free channel: [JuicyFox Official Life](https://t.me/JuicyFoxOfficialLife)",
+  "life_promo": "Wanna see more of me? Tap here 😘\n⬇️⬇️⬇️\n👉 <a href='https://t.me/JuisyFoxOfficialLife'>JUICY LIFE CHANNEL</a>",
   "choose_action": "Choose an action below:",
   "choose_post_plan": "Choose action",
   "choose_cur": "Choose payment method: {amount}⭐",

--- a/locales/es.json
+++ b/locales/es.json
@@ -9,6 +9,7 @@
   "activate_chat": "See you my chaT 💬",
   "life_link": "👀 Mi canal: {url}",
   "my_channel": "👀 Mi canal gratuito: [JuicyFox Official Life](https://t.me/JuicyFoxOfficialLife)",
+  "life_promo": "¿Quieres ver más de mí? Toca aquí 😘\n⬇️⬇️⬇️\n👉 <a href='https://t.me/JuisyFoxOfficialLife'>JUICY LIFE CHANNEL</a>",
   "choose_action": "Elige una acción abajo:",
   "choose_post_plan": "Elige acción",
   "choose_cur": "Elige método de pago: {amount}⭐",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -9,6 +9,7 @@
   "activate_chat": "See you my chaT 💬",
   "life_link": "👀 Мой канал: {url}",
   "my_channel": "👀 Мой бесплатный канал: [JuicyFox Official Life](https://t.me/JuicyFoxOfficialLife)",
+  "life_promo": "Хочешь увидеть больше? Жми сюда 😘\n⬇️⬇️⬇️\n👉 <a href='https://t.me/JuisyFoxOfficialLife'>JUICY LIFE CHANNEL</a>",
   "choose_action": "Выбери действие ниже:",
   "choose_post_plan": "Выберите действие",
   "choose_cur": "Выбери способ оплаты: {amount}⭐",

--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -77,11 +77,10 @@ async def cmd_start(message: Message, state: FSMContext) -> None:
         caption=tr(lang, "menu", name=message.from_user.first_name),
     )
     if LIFE_URL:
-        # REGION AI: free channel link without preview
+        # REGION AI: life promo link without preview
         await message.answer(
-            tr(lang, "my_channel"),
-            reply_markup=reply_menu(lang),
-            parse_mode="Markdown",
+            tr(lang, "life_promo"),
+            parse_mode="HTML",
             disable_web_page_preview=True,
         )
         # END REGION AI


### PR DESCRIPTION
## Summary
- add new `life_promo` translations for EN, RU, ES locales
- send HTML promo message with link to JUICY LIFE CHANNEL

## Testing
- `ruff check modules/ui_membership/handlers.py`
- `python -m json.tool locales/en.json`
- `python -m json.tool locales/ru.json`
- `python -m json.tool locales/es.json`
- `python -c "import importlib; importlib.import_module('modules.ui_membership.handlers')"` *(fails: TELEGRAM_TOKEN is required in environment or YAML config)*
- `uvicorn api.webhook:app --port 0` *(fails: Attribute "app" not found in module "api.webhook")*
- `pytest modules/ui_membership -q`

------
https://chatgpt.com/codex/tasks/task_e_68c7169f93b8832a93b30cc50c82c9d4