### PR TITLE
fix: correct life_promo channel links

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -9,7 +9,7 @@
   "activate_chat": "See you my chaT 💬",
   "life_link": "👀 My channel: {url}",
   "my_channel": "👀 My free channel: [JuicyFox Official Life](https://t.me/JuicyFoxOfficialLife)",
-  "life_promo": "Wanna see more of me? Tap here 😘\n⬇️⬇️⬇️\n👉 <a href='https://t.me/JuisyFoxOfficialLife'>JUICY LIFE CHANNEL</a>",
+  "life_promo": "Wanna see more of me? Tap here 😘\n⬇️⬇️⬇️\n👉 <a href='https://t.me/JuicyFoxOfficialLife'>JUICY LIFE CHANNEL</a>",
   "choose_action": "Choose an action below:",
   "choose_post_plan": "Choose action",
   "choose_cur": "Choose payment method: {amount}⭐",

--- a/locales/es.json
+++ b/locales/es.json
@@ -9,7 +9,7 @@
   "activate_chat": "See you my chaT 💬",
   "life_link": "👀 Mi canal: {url}",
   "my_channel": "👀 Mi canal gratuito: [JuicyFox Official Life](https://t.me/JuicyFoxOfficialLife)",
-  "life_promo": "¿Quieres ver más de mí? Toca aquí 😘\n⬇️⬇️⬇️\n👉 <a href='https://t.me/JuisyFoxOfficialLife'>JUICY LIFE CHANNEL</a>",
+  "life_promo": "¿Quieres ver más de mí? Toca aquí 😘\n⬇️⬇️⬇️\n👉 <a href='https://t.me/JuicyFoxOfficialLife'>JUICY LIFE CHANNEL</a>",
   "choose_action": "Elige una acción abajo:",
   "choose_post_plan": "Elige acción",
   "choose_cur": "Elige método de pago: {amount}⭐",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -9,7 +9,7 @@
   "activate_chat": "See you my chaT 💬",
   "life_link": "👀 Мой канал: {url}",
   "my_channel": "👀 Мой бесплатный канал: [JuicyFox Official Life](https://t.me/JuicyFoxOfficialLife)",
-  "life_promo": "Хочешь увидеть больше? Жми сюда 😘\n⬇️⬇️⬇️\n👉 <a href='https://t.me/JuisyFoxOfficialLife'>JUICY LIFE CHANNEL</a>",
+  "life_promo": "Хочешь увидеть больше? Жми сюда 😘\n⬇️⬇️⬇️\n👉 <a href='https://t.me/JuicyFoxOfficialLife'>JUICY LIFE CHANNEL</a>",
   "choose_action": "Выбери действие ниже:",
   "choose_post_plan": "Выберите действие",
   "choose_cur": "Выбери способ оплаты: {amount}⭐",


### PR DESCRIPTION
## Summary
- fix incorrect life_promo links in EN, RU, and ES locales

## Testing
- `python -m json.tool locales/en.json >/tmp/en.json`
- `python -m json.tool locales/ru.json >/tmp/ru.json`
- `python -m json.tool locales/es.json >/tmp/es.json`
- `flake8 locales/en.json locales/ru.json locales/es.json` *(fails: E501 line too long, E121 continuation line under-indented)*
- `uvicorn api.webhook:app --port 0` *(fails: Attribute "app" not found in module "api.webhook")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c71a781028832a9552417228caf098