### PR TITLE
feat: show VIP banner

### DIFF
--- a/modules/constants/paths.py
+++ b/modules/constants/paths.py
@@ -5,3 +5,6 @@ BASE_DIR = Path(__file__).resolve().parents[2]
 DATA_DIR = BASE_DIR / "data"
 
 START_PHOTO = DATA_DIR / "start.jpg"
+# REGION AI: vip photo path
+VIP_PHOTO = DATA_DIR / "vip_banner.jpg"
+# END REGION AI

--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -16,7 +16,9 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 from modules.common.i18n import tr
 from modules.constants.currencies import CURRENCIES
 from modules.constants.prices import VIP_PRICE_USD
-from modules.constants.paths import START_PHOTO
+# REGION AI: imports
+from modules.constants.paths import START_PHOTO, VIP_PHOTO
+# END REGION AI
 from modules.payments import create_invoice
 
 from shared.db.repo import (
@@ -109,7 +111,15 @@ async def back_to_main(cq: CallbackQuery, state: FSMContext) -> None:
 @router.callback_query(F.data.in_({"ui:vip", "vip"}))
 async def show_vip(cq: CallbackQuery) -> None:
     lang = get_lang(cq.from_user)
-    await cq.message.edit_text(tr(lang, "vip_club_description"), reply_markup=vip_currency_kb(lang))
+    # REGION AI: vip club banner
+    await cq.message.delete()
+    await cq.message.answer_photo(
+        FSInputFile(VIP_PHOTO),
+        caption=tr(lang, "vip_club_description"),
+        reply_markup=vip_currency_kb(lang),
+        parse_mode="HTML",
+    )
+    # END REGION AI
 
 
 @router.message(Command("currency"))


### PR DESCRIPTION
## Summary
- add constant for VIP banner photo
- show VIP banner with description and payment buttons when opening VIP CLUB

## Testing
- `ruff check modules/constants/paths.py modules/ui_membership/handlers.py`
- `python -c "import importlib; importlib.import_module('modules.constants.paths'); importlib.import_module('modules.ui_membership.handlers')"`
- `timeout 5 uvicorn api.webhook:app --port 0` *(fails: TELEGRAM_TOKEN is required in environment or YAML config)*
- `pytest modules/constants/paths.py modules/ui_membership/handlers.py` *(fails: ModuleNotFoundError: No module named 'modules')*


------
https://chatgpt.com/codex/tasks/task_e_68c72149d204832a819df4d461e67423