### PR TITLE
fix: send VIP CLUB banner with string path

### DIFF
--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -112,9 +112,10 @@ async def back_to_main(cq: CallbackQuery, state: FSMContext) -> None:
 async def show_vip(cq: CallbackQuery) -> None:
     lang = get_lang(cq.from_user)
     # REGION AI: vip club banner
+    # fix: ensure FSInputFile receives string path for VIP banner
     await cq.message.delete()
     await cq.message.answer_photo(
-        FSInputFile(VIP_PHOTO),
+        FSInputFile(str(VIP_PHOTO)),
         caption=tr(lang, "vip_club_description"),
         reply_markup=vip_currency_kb(lang),
         parse_mode="HTML",


### PR DESCRIPTION
## Summary
- fix VIP CLUB banner upload by passing string path to FSInputFile

## Testing
- `ruff check modules/ui_membership/handlers.py`
- `python -c "import importlib; importlib.import_module('modules.ui_membership.handlers')"` *(fails: TELEGRAM_TOKEN is required)*
- `uvicorn api.webhook:app --port 0` *(fails: TELEGRAM_TOKEN is required)*
- `pytest modules/ui_membership/handlers.py` *(fails: ModuleNotFoundError: No module named 'modules')*


------
https://chatgpt.com/codex/tasks/task_e_68c723a7b3a0832a819fa16a9cad43da