### PR TITLE
fix: make VIP club handler more flexible

### DIFF
--- a/modules/chat_relay/handlers.py
+++ b/modules/chat_relay/handlers.py
@@ -243,7 +243,10 @@ async def _send_record(msg: Message, chat_id: int, header: Optional[str] | None 
 # END REGION AI
 
 # REGION AI: vip club handler
-@router.message(F.chat.type == "private", F.text == "VIP CLUB 🔞 - 19 $")
+@router.message(
+    F.chat.type == "private",
+    F.text.startswith("/vip") | F.text.startswith("VIP CLUB"),
+)
 async def vip_club(msg: Message) -> None:
     lang = get_lang(msg.from_user)
     with open("data/vip_banner.jpg", "rb") as photo:


### PR DESCRIPTION
## Summary
- broaden VIP club handler trigger to catch `/vip` command or text beginning with `VIP CLUB`

## Testing
- `ruff check modules/chat_relay/handlers.py`
- `python - <<'PY'
import importlib
importlib.import_module('modules.chat_relay.handlers')
print('imported')
PY`
- `uvicorn api.webhook:app --port 0` *(fails: Attribute "app" not found in module "api.webhook")*
- `pytest modules/chat_relay -q`

------
https://chatgpt.com/codex/tasks/task_e_68c7379146b8832abc02bcbb18bd24b5