### PR TITLE
fix: send VIP CLUB banner like start photo

### DIFF
--- a/modules/chat_relay/handlers.py
+++ b/modules/chat_relay/handlers.py
@@ -12,6 +12,7 @@ from aiogram.exceptions import TelegramNetworkError
 from modules.common.i18n import tr
 from shared.utils.lang import get_lang
 from modules.ui_membership.keyboards import vip_currency_kb
+from modules.constants.paths import VIP_PHOTO
 try:
     from shared.db.repo import (
         get_active_invoice,
@@ -249,7 +250,7 @@ async def _send_record(msg: Message, chat_id: int, header: Optional[str] | None 
 )
 async def vip_club(msg: Message) -> None:
     lang = get_lang(msg.from_user)
-    with open("data/vip_banner.jpg", "rb") as photo:
+    with open(VIP_PHOTO, "rb") as photo:
         await msg.answer_photo(
             photo,
             caption=tr(lang, "vip_club_description"),


### PR DESCRIPTION
## Summary
- use VIP_PHOTO constant to load VIP banner like start photo

## Testing
- `ruff check modules/chat_relay/handlers.py`
- `python - <<'PY'
import importlib
importlib.import_module('modules.chat_relay.handlers')
PY` *(fails: TELEGRAM_TOKEN is required)*
- `uvicorn api.webhook:app --port 0` *(fails: Attribute 'app' not found)*
- `pytest modules/chat_relay -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7c315b254832a9fd8465fd0c69180