### PR TITLE
Ensure VIP banner fallback in vip_club

### DIFF
--- a/modules/chat_relay/handlers.py
+++ b/modules/chat_relay/handlers.py
@@ -252,12 +252,13 @@ async def _send_record(msg: Message, chat_id: int, header: Optional[str] | None 
 )
 async def vip_club(msg: Message) -> None:
     lang = get_lang(msg.from_user)
+    banner: FSInputFile | str
     if VIP_PHOTO.exists():
-        photo: FSInputFile | str = FSInputFile(VIP_PHOTO)
+        banner = FSInputFile(VIP_PHOTO)
     else:
-        photo = VIP_BANNER_FILE_ID
+        banner = VIP_BANNER_FILE_ID
     await msg.answer_photo(
-        photo,
+        banner,
         caption=tr(lang, "vip_club_description"),
         reply_markup=vip_currency_kb(lang),
         parse_mode="HTML",


### PR DESCRIPTION
## Summary
- ensure VIP Club sends banner via FSInputFile or fallback file_id

## Testing
- `ruff check modules/chat_relay/handlers.py`
- `python - <<'PY'
import importlib
importlib.import_module('modules.chat_relay.handlers')
print('import-ok')
PY`
- `timeout 5 uvicorn api.webhook:app --port 0`
- `pytest modules/chat_relay/handlers.py`

------
https://chatgpt.com/codex/tasks/task_e_68c7d987edf8832a94aa676eba03bc7c