### PR TITLE
fix: update Juicy Life menu button

### DIFF
--- a/modules/ui_membership/keyboards.py
+++ b/modules/ui_membership/keyboards.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+# fix: update Juicy Life button text and link
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 from aiogram.types import InlineKeyboardMarkup, ReplyKeyboardMarkup, KeyboardButton, InlineKeyboardButton
 
@@ -10,7 +11,7 @@ from shared.config.env import config
 # END REGION
 
 # REGION AI: life channel url
-LIFE_CHANNEL_URL = config.life_url or ""
+LIFE_CHANNEL_URL = config.life_url or "https://t.me/JuicyFoxOfficialLife"
 # END REGION AI
 
 
@@ -20,7 +21,7 @@ def main_menu_kb(lang: str) -> InlineKeyboardMarkup:
     """Главное меню: Life, Luxury, VIP, Chat."""
     b = InlineKeyboardBuilder()
     # REGION AI: direct life channel link
-    b.button(text=tr(lang, "btn_life"), url=LIFE_CHANNEL_URL)
+    b.button(text="JUICY LIFE 👀", url=LIFE_CHANNEL_URL)
     # END REGION AI
     # b.button(text=tr(lang, "btn_lux"), callback_data="ui:luxury")  # temporarily hidden
     # REGION AI: remove price from VIP button


### PR DESCRIPTION
## Summary
- fix life menu button text and link to correct Juicy Life channel

## Testing
- `ruff check modules/ui_membership/keyboards.py`
- `flake8 modules/ui_membership/keyboards.py` *(fails: command not found)*
- `TELEGRAM_TOKEN=1 python - <<'PY'\nimport importlib\nimportlib.import_module('modules.ui_membership.keyboards')\nprint('IMPORT_OK')\nPY`
- `TELEGRAM_TOKEN=1 uvicorn api.webhook:app --port 0 --log-level warning` *(fails: app attribute not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7e07573c8832a97243a6cad574765