### PR TITLE
fix: unify VIP pricing to 19 USD

### DIFF
--- a/modules/payments/handlers.py
+++ b/modules/payments/handlers.py
@@ -9,7 +9,7 @@ from aiogram.types import CallbackQuery
 from aiogram.types import Message, LabeledPrice
 from modules.access import grant
 # REGION AI: price constants
-from modules.constants.prices import VIP_PRICE_USD
+from shared.config.env import config
 # END REGION AI
 # END REGION AI
 from modules.common.i18n import tr
@@ -46,7 +46,7 @@ async def cancel_payment(callback: CallbackQuery, state: FSMContext) -> None:
     )
 
     if plan_callback.startswith("vipay") or plan_code.startswith("vip"):
-        desc = tr(lang, "vip_club_description")
+        desc = tr(lang, "vip_club_description", amount=int(config.vip_price_usd))
         kb = vip_currency_kb(lang)
         await state.clear()
         await state.update_data(
@@ -115,8 +115,8 @@ async def pay_stars(callback: CallbackQuery, state: FSMContext) -> None:
             await state.update_data(
                 plan_code="vip_30d",
                 plan_callback="vip",
-                plan_name=f"VIP CLUB - {int(VIP_PRICE_USD)}$",
-                stars=int(VIP_PRICE_USD * 100),
+                plan_name=f"VIP CLUB - {int(config.vip_price_usd)}$",
+                stars=int(config.vip_price_usd * 100),
             )
             data = await state.get_data()
             plan_code = data.get("plan_code") or ""
@@ -127,11 +127,11 @@ async def pay_stars(callback: CallbackQuery, state: FSMContext) -> None:
             else "donate"
         )
         title = data.get("plan_name") or (
-            f"VIP CLUB - {int(VIP_PRICE_USD)}$"
+            f"VIP CLUB - {int(config.vip_price_usd)}$"
             if purchase == "vip"
             else purchase
         )
-        stars = int(data.get("stars") or int(VIP_PRICE_USD * 100))
+        stars = int(data.get("stars") or int(config.vip_price_usd * 100))
     await callback.message.answer_invoice(
         title=title,
         description=tr(lang, "stars_payment_desc"),

--- a/modules/ui_membership/handlers.py
+++ b/modules/ui_membership/handlers.py
@@ -15,8 +15,8 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 # текст/локализация и валюты берём из актуальных модулей
 from modules.common.i18n import tr
 from modules.constants.currencies import CURRENCIES
-from modules.constants.prices import VIP_PRICE_USD
-# REGION AI: imports
+# REGION AI: VIP price from config
+from shared.config.env import config
 from modules.constants.paths import START_PHOTO, VIP_PHOTO
 # END REGION AI
 from modules.payments import create_invoice
@@ -116,13 +116,13 @@ async def show_vip(cq: CallbackQuery) -> None:
         photo = FSInputFile(VIP_PHOTO)
         await cq.message.answer_photo(
             photo,
-            caption=tr(lang, "vip_club_description"),
+            caption=tr(lang, "vip_club_description", amount=int(config.vip_price_usd)),
             reply_markup=vip_currency_kb(lang),
             parse_mode="HTML",
         )
     else:
         await cq.message.answer(
-            tr(lang, "vip_club_description"),
+            tr(lang, "vip_club_description", amount=int(config.vip_price_usd)),
             reply_markup=vip_currency_kb(lang),
             parse_mode="HTML",
         )
@@ -134,7 +134,7 @@ async def cmd_currency(message: Message) -> None:
     """Show currency menu for VIP subscription."""
     lang = get_lang(message.from_user)
     await message.answer(
-        tr(lang, "choose_cur", amount=VIP_PRICE_USD),
+        tr(lang, "choose_cur", amount=config.vip_price_usd),
         reply_markup=vip_currency_kb(lang),
     )
 
@@ -154,7 +154,7 @@ def _invoice_url(inv: Any) -> Optional[str]:
 async def pay_vip(callback: CallbackQuery, state: FSMContext) -> None:
     lang = get_lang(callback.from_user)
     currency = "USDT"
-    amount = VIP_PRICE_USD
+    amount = config.vip_price_usd
     await state.update_data(
         plan_name="VIP CLUB",
         price=float(amount),
@@ -213,11 +213,11 @@ async def vipay_currency(callback: CallbackQuery, state: FSMContext) -> None:
         "vipay_currency: user=%s currency=%s amount=%s",
         callback.from_user.id,
         cur,
-        VIP_PRICE_USD,
+        config.vip_price_usd,
     )
     await state.update_data(
         plan_name="VIP CLUB",
-        price=float(VIP_PRICE_USD),
+        price=float(config.vip_price_usd),
         period=30,
         plan_callback="vipay",
     )
@@ -226,7 +226,7 @@ async def vipay_currency(callback: CallbackQuery, state: FSMContext) -> None:
     inv = await create_invoice(
         user_id=callback.from_user.id,
         plan_code="vip_30d",
-        amount_usd=float(VIP_PRICE_USD),
+        amount_usd=float(config.vip_price_usd),
         meta=_build_meta(callback.from_user.id, "vip_30d", cur),
         asset=cur,
     )
@@ -240,7 +240,7 @@ async def vipay_currency(callback: CallbackQuery, state: FSMContext) -> None:
             cur,
             "vipay",
             "VIP CLUB",
-            float(VIP_PRICE_USD),
+            float(config.vip_price_usd),
             30,
         )
     url = _invoice_url(inv)

--- a/shared/config/env.py
+++ b/shared/config/env.py
@@ -73,7 +73,9 @@ class Config:
     model_name: str = "Juicy Fox"
     vip_url: Optional[str] = None
     life_url: Optional[str] = None
-    vip_price_usd: float = 35.0
+    # REGION AI: default VIP price
+    vip_price_usd: float = 19.0
+    # END REGION AI
     chat_price_usd: float = 15.0
     chat_group_id: int = 0
     history_group_id: Optional[int] = None
@@ -204,7 +206,16 @@ def load_config(bot_id: Optional[str] = None) -> Config:
             default=yaml_data.get("life_url") or "https://t.me/JuicyFoxOfficialLife",
         ),
         # END REGION AI
-        vip_price_usd=float(_get_alias(env, "VIP_PRICE_USD", "VIP_30D_USD", default=yaml_data.get("vip_price_usd", 35))),
+        # REGION AI: VIP price default 19
+        vip_price_usd=float(
+            _get_alias(
+                env,
+                "VIP_PRICE_USD",
+                "VIP_30D_USD",
+                default=yaml_data.get("vip_price_usd", 19),
+            )
+        ),
+        # END REGION AI
         chat_price_usd=float(_get_alias(env, "CHAT_PRICE_USD", "CHAT_30D_USD", default=yaml_data.get("chat_price_usd", 15))),
         chat_group_id=int(_get_alias(env, "CHAT_GROUP_ID", default=_yaml_int("chat_group_id", 0) or 0) or 0),
         history_group_id=_yaml_int("history_group_id") or int(_get_alias(env, "HISTORY_GROUP_ID", default="0") or 0) or None,


### PR DESCRIPTION
## Summary
- set VIP default price to 19 USD and propagate to payments
- calculate Stars and invoices from configured VIP price
- use env config for VIP pricing in UI membership

## Testing
- `flake8 shared/config/env.py modules/payments/handlers.py modules/ui_membership/handlers.py` *(fails: E501 line too long, etc.)*
- `TELEGRAM_TOKEN=x BOT_ID=y python -c "import importlib; importlib.import_module('shared.config.env')"`
- `TELEGRAM_TOKEN=x BOT_ID=y python -c "import importlib; importlib.import_module('modules.payments.handlers')"`
- `TELEGRAM_TOKEN=x BOT_ID=y python -c "import importlib; importlib.import_module('modules.ui_membership.handlers')"`
- `TELEGRAM_TOKEN=x BOT_ID=y uvicorn api.webhook:app --port 0` *(fails: Attribute "app" not found)*
- `TELEGRAM_TOKEN=x BOT_ID=y pytest modules/payments/handlers.py modules/ui_membership/handlers.py shared/config/env.py` *(fails: ModuleNotFoundError: No module named 'modules')*

------
https://chatgpt.com/codex/tasks/task_e_68c7f062c6a0832a955b7999a0bfaae0