### PR TITLE
fix: correct Juicy Life inline button URL

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -9,7 +9,7 @@
   "activate_chat": "See you my chaT 💬",
   "life_link": "👀 My channel: {url}",
   "my_channel": "👀 My free channel: [JuicyFox Official Life](https://t.me/JuicyFoxOfficialLife)",
-  "life_promo": "Wanna see more of me? Tap here 😘\n⬇️⬇️⬇️\n👉 <a href='https://t.me/JuicyFoxOfficialLife'>JUICY LIFE CHANNEL</a>",
+  "life_promo": "Wanna see more of me? Tap here 😘\n⬇️⬇️⬇️\n👉 <a href=\"https://t.me/JuicyFoxOfficialLife\">JUICY LIFE CHANNEL</a>",
   "choose_action": "Choose an action below:",
   "choose_post_plan": "Choose action",
   "choose_cur": "Choose payment method: {amount}⭐",

--- a/locales/es.json
+++ b/locales/es.json
@@ -9,7 +9,7 @@
   "activate_chat": "See you my chaT 💬",
   "life_link": "👀 Mi canal: {url}",
   "my_channel": "👀 Mi canal gratuito: [JuicyFox Official Life](https://t.me/JuicyFoxOfficialLife)",
-  "life_promo": "¿Quieres ver más de mí? Toca aquí 😘\n⬇️⬇️⬇️\n👉 <a href='https://t.me/JuicyFoxOfficialLife'>JUICY LIFE CHANNEL</a>",
+  "life_promo": "¿Quieres ver más de mí? Toca aquí 😘\n⬇️⬇️⬇️\n👉 <a href=\"https://t.me/JuicyFoxOfficialLife\">JUICY LIFE CHANNEL</a>",
   "choose_action": "Elige una acción abajo:",
   "choose_post_plan": "Elige acción",
   "choose_cur": "Elige método de pago: {amount}⭐",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -9,7 +9,7 @@
   "activate_chat": "See you my chaT 💬",
   "life_link": "👀 Мой канал: {url}",
   "my_channel": "👀 Мой бесплатный канал: [JuicyFox Official Life](https://t.me/JuicyFoxOfficialLife)",
-  "life_promo": "Хочешь увидеть больше? Жми сюда 😘\n⬇️⬇️⬇️\n👉 <a href='https://t.me/JuicyFoxOfficialLife'>JUICY LIFE CHANNEL</a>",
+  "life_promo": "Хочешь увидеть больше? Жми сюда 😘\n⬇️⬇️⬇️\n👉 <a href=\"https://t.me/JuicyFoxOfficialLife\">JUICY LIFE CHANNEL</a>",
   "choose_action": "Выбери действие ниже:",
   "choose_post_plan": "Выберите действие",
   "choose_cur": "Выбери способ оплаты: {amount}⭐",

--- a/modules/ui_membership/keyboards.py
+++ b/modules/ui_membership/keyboards.py
@@ -16,7 +16,12 @@ def main_menu_kb(lang: str) -> InlineKeyboardMarkup:
     """Главное меню: Life, Luxury, VIP, Chat."""
     b = InlineKeyboardBuilder()
     # REGION AI: direct life channel link
-    b.button(text="JUICY LIFE 👀", url=config.life_url or "https://t.me/JuicyFoxOfficialLife")
+    b.add(
+        InlineKeyboardButton(
+            text="JUICY LIFE 👀",
+            url=config.life_url or "https://t.me/JuicyFoxOfficialLife",
+        )
+    )
     # END REGION AI
     # b.button(text=tr(lang, "btn_lux"), callback_data="ui:luxury")  # temporarily hidden
     # REGION AI: remove price from VIP button


### PR DESCRIPTION
## Summary
- fix Juicy Life button to open channel with valid link
- ensure life_promo texts use https://t.me/JuicyFoxOfficialLife

## Testing
- `ruff check modules/ui_membership/keyboards.py locales/en.json locales/ru.json locales/es.json`
- `flake8 modules/ui_membership/keyboards.py`
- `python -m json.tool locales/en.json`
- `python -m json.tool locales/ru.json`
- `python -m json.tool locales/es.json`
- `python -c "import importlib; importlib.import_module('modules.ui_membership.keyboards')"` *(fails: TELEGRAM_TOKEN is required)*
- `uvicorn api.webhook:app --port 0` *(fails: Attribute "app" not found in module "api.webhook")*
- `pytest modules/ui_membership/keyboards.py` *(fails: ModuleNotFoundError: No module named 'modules')*

------
https://chatgpt.com/codex/tasks/task_e_68c91ad99a4c832a9c6c8b03dc316884