### PR TITLE
Add retry helper for Telegram sends

### DIFF
--- a/configs/bots/sample_bot.yaml
+++ b/configs/bots/sample_bot.yaml
@@ -24,6 +24,8 @@ features:
 # Pricing configuration.  If omitted, default values are used.
 vip_price_usd: 35
 chat_price_usd: 15
+telegram_send_attempts: 3
+telegram_send_base_delay: 1.0
 
 # Identifiers for groups/channels used by the bot.  These should be
 # integers corresponding to Telegram chat IDs.  Negative values indicate

--- a/modules/access/__init__.py
+++ b/modules/access/__init__.py
@@ -8,6 +8,8 @@ from typing import Any, Dict, Optional
 
 from aiogram import Bot
 
+from shared.utils.telegram import send_with_retry
+
 log = logging.getLogger("juicyfox.access")
 
 # Карта планов → переменная окружения с chat_id и срок действия (дней)
@@ -75,10 +77,12 @@ async def grant(user_id: int, plan_code: str, *, bot: Optional[Bot] = None) -> D
 
     # Мягко отправим пользователю ссылку
     try:
-        await bot.send_message(
-            chat_id=user_id,
-            text=f"✅ Доступ по плану **{plan_code}**. Срок до {until.date()}\nСсылка: {link.invite_link}",
+        await send_with_retry(
+            bot.send_message,
+            user_id,
+            f"✅ Доступ по плану **{plan_code}**. Срок до {until.date()}\nСсылка: {link.invite_link}",
             parse_mode="Markdown",
+            logger=log,
         )
     except Exception as e:
         log.warning("cannot DM user %s invite link (maybe user never started bot): %s", user_id, e)

--- a/modules/history/handlers.py
+++ b/modules/history/handlers.py
@@ -31,6 +31,8 @@ from aiogram import Router, Bot
 from aiogram.filters import Command, CommandObject
 from aiogram.types import Message
 
+from shared.utils.telegram import send_with_retry
+
 logger = logging.getLogger("juicyfox.history")
 
 router = Router()
@@ -130,26 +132,31 @@ async def _send_record(bot: Bot, chat_id: int, rec: Dict[str, Any]) -> None:
     file_id = rec.get("file_id") or None
     try:
         if typ == "text" or (typ is None and not file_id):
-            await bot.send_message(chat_id, text or "")
+            await send_with_retry(bot.send_message, chat_id, text or "", logger=logger)
         elif typ == "photo":
-            await bot.send_photo(chat_id, file_id, caption=text)
+            await send_with_retry(bot.send_photo, chat_id, file_id, caption=text, logger=logger)
         elif typ == "video":
-            await bot.send_video(chat_id, file_id, caption=text)
+            await send_with_retry(bot.send_video, chat_id, file_id, caption=text, logger=logger)
         elif typ == "voice":
-            await bot.send_voice(chat_id, file_id, caption=text)
+            await send_with_retry(bot.send_voice, chat_id, file_id, caption=text, logger=logger)
         elif typ == "animation":
-            await bot.send_animation(chat_id, file_id, caption=text)
+            await send_with_retry(bot.send_animation, chat_id, file_id, caption=text, logger=logger)
         elif typ == "document":
-            await bot.send_document(chat_id, file_id, caption=text)
+            await send_with_retry(bot.send_document, chat_id, file_id, caption=text, logger=logger)
         elif typ == "audio":
-            await bot.send_audio(chat_id, file_id, caption=text)
+            await send_with_retry(bot.send_audio, chat_id, file_id, caption=text, logger=logger)
         elif typ == "video_note":
-            await bot.send_video_note(chat_id, file_id)
+            await send_with_retry(bot.send_video_note, chat_id, file_id, logger=logger)
         elif typ == "sticker":
-            await bot.send_sticker(chat_id, file_id)
+            await send_with_retry(bot.send_sticker, chat_id, file_id, logger=logger)
         else:
             # Unknown or unsupported type; send the text with a marker
-            await bot.send_message(chat_id, f"[{typ}] {text or ''}")
+            await send_with_retry(
+                bot.send_message,
+                chat_id,
+                f"[{typ}] {text or ''}",
+                logger=logger,
+            )
     except Exception as e:
         logger.warning("history: failed to send record (%s): %s", typ, e)
 

--- a/modules/posting/worker.py
+++ b/modules/posting/worker.py
@@ -10,6 +10,8 @@ from typing import Any, Dict, List, Tuple
 import aiosqlite
 from aiogram import Bot
 
+from shared.utils.telegram import send_with_retry
+
 log = logging.getLogger("juicyfox.posting.worker")
 
 DB_PATH = os.getenv("DB_PATH", "/app/data/juicyfox.sqlite")
@@ -99,15 +101,15 @@ async def _send(bot: Bot, job: Dict[str, Any]) -> None:
     file_id = job.get("file_id")
 
     if typ == "text":
-        await bot.send_message(chat_id, text or "")
+        await send_with_retry(bot.send_message, chat_id, text or "", logger=log)
     elif typ == "photo":
-        await bot.send_photo(chat_id, file_id, caption=text)
+        await send_with_retry(bot.send_photo, chat_id, file_id, caption=text, logger=log)
     elif typ == "video":
-        await bot.send_video(chat_id, file_id, caption=text)
+        await send_with_retry(bot.send_video, chat_id, file_id, caption=text, logger=log)
     elif typ == "document":
-        await bot.send_document(chat_id, file_id, caption=text)
+        await send_with_retry(bot.send_document, chat_id, file_id, caption=text, logger=log)
     elif typ == "animation":
-        await bot.send_animation(chat_id, file_id, caption=text)
+        await send_with_retry(bot.send_animation, chat_id, file_id, caption=text, logger=log)
     else:
         raise RuntimeError(f"unsupported type: {typ}")
 

--- a/shared/utils/__init__.py
+++ b/shared/utils/__init__.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from contextlib import suppress
 
-__all__ = ["logging", "time", "idempotency", "metrics"]
+__all__ = ["logging", "time", "idempotency", "metrics", "telegram"]
 
 # Attempt to import submodules.  Failures are suppressed to allow
 # optional dependencies (e.g. prometheus_client) to be absent.
@@ -33,3 +33,5 @@ with suppress(Exception):
     from . import idempotency  # type: ignore  # noqa: F401
 with suppress(Exception):
     from . import metrics  # type: ignore  # noqa: F401
+with suppress(Exception):
+    from . import telegram  # type: ignore  # noqa: F401

--- a/shared/utils/telegram.py
+++ b/shared/utils/telegram.py
@@ -1,0 +1,115 @@
+"""Telegram helper utilities for JuicyFox bots."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Awaitable, Callable, Optional, TypeVar
+
+try:
+    from aiogram.exceptions import TelegramNetworkError
+except Exception:  # pragma: no cover - fallback when aiogram is unavailable
+    class TelegramNetworkError(Exception):
+        """Fallback Telegram network error used when aiogram is missing."""
+
+        pass
+
+try:
+    from shared.config import config
+except Exception:  # pragma: no cover - configuration may be unavailable during import
+    config = None  # type: ignore
+
+T = TypeVar("T")
+
+AsyncCall = Callable[..., Awaitable[T]]
+
+
+def _qualname(func: Callable[..., Any]) -> str:
+    """Return a readable name for logging purposes."""
+    return getattr(func, "__qualname__", repr(func))
+
+
+async def send_with_retry(
+    func: AsyncCall[T],
+    *args: Any,
+    attempts: Optional[int] = None,
+    base_delay: Optional[float] = None,
+    logger: Optional[logging.Logger] = None,
+    **kwargs: Any,
+) -> T:
+    """Execute ``func`` with retries on :class:`TelegramNetworkError`.
+
+    Parameters
+    ----------
+    func:
+        Awaitable Telegram API call (e.g. ``bot.send_message`` or
+        ``message.answer``).
+    attempts:
+        Override number of attempts.  Defaults to the value provided by
+        configuration (``config.telegram_send_attempts``) or ``3``.
+    base_delay:
+        Base delay in seconds before retrying.  Each subsequent retry uses an
+        exponential backoff: ``delay * 2 ** (attempt - 1)``.  Defaults to
+        ``config.telegram_send_base_delay`` or ``1.0`` seconds.
+    logger:
+        Optional logger used for diagnostics.  Falls back to a module-wide
+        logger named ``"juicyfox.telegram"``.
+
+    Returns
+    -------
+    The result of ``func`` on success.  If all retries fail with a
+    ``TelegramNetworkError`` the exception is re-raised, preserving previous
+    behaviour of direct Telegram API calls.
+    """
+
+    log = logger or logging.getLogger("juicyfox.telegram")
+
+    cfg_attempts = getattr(config, "telegram_send_attempts", None) if config else None
+    cfg_delay = getattr(config, "telegram_send_base_delay", None) if config else None
+
+    try:
+        attempts_val = int(attempts if attempts is not None else (cfg_attempts or 3))
+    except Exception:
+        attempts_val = 3
+    if attempts_val < 1:
+        attempts_val = 1
+
+    try:
+        delay_val = float(base_delay if base_delay is not None else (cfg_delay if cfg_delay is not None else 1.0))
+    except Exception:
+        delay_val = 1.0
+    if delay_val < 0:
+        delay_val = 0.0
+
+    last_error: Optional[TelegramNetworkError] = None
+
+    for attempt_num in range(1, attempts_val + 1):
+        try:
+            return await func(*args, **kwargs)
+        except TelegramNetworkError as err:
+            last_error = err
+            if attempt_num >= attempts_val:
+                log.exception(
+                    "send_with_retry: %s failed after %s attempts due to network error",
+                    _qualname(func),
+                    attempts_val,
+                )
+                raise
+            sleep_for = delay_val * (2 ** (attempt_num - 1))
+            log.warning(
+                "send_with_retry: %s network error on attempt %s/%s; retrying in %.2fs",
+                _qualname(func),
+                attempt_num,
+                attempts_val,
+                sleep_for,
+            )
+            await asyncio.sleep(sleep_for)
+        except Exception:
+            log.exception(
+                "send_with_retry: %s raised unexpected exception", _qualname(func)
+            )
+            raise
+
+    # Should never be reached because the loop returns on success or raises.
+    if last_error:
+        raise last_error
+    raise RuntimeError("send_with_retry: execution finished without result")


### PR DESCRIPTION
## Summary
- add a shared `send_with_retry` helper that retries Telegram API calls on network errors
- extend the configuration with retry settings and export the helper from `shared.utils`
- route all `bot.send_*` and `message.answer_*` calls in modules through the new helper

## Testing
- python -m compileall shared modules

------
https://chatgpt.com/codex/tasks/task_e_68c999387830832a8282c0769486bbaa