### PR TITLE
Support CRYPTO_BOT_TOKEN fallback for payments

### DIFF
--- a/modules/payments/providers/cryptobot.py
+++ b/modules/payments/providers/cryptobot.py
@@ -12,7 +12,7 @@ from .. import InvoiceResponse, ProviderError
 
 log = logging.getLogger("juicyfox.payments.providers.cryptobot")
 
-CRYPTOBOT_TOKEN = os.getenv("CRYPTOBOT_TOKEN")
+CRYPTOBOT_TOKEN = os.getenv("CRYPTOBOT_TOKEN") or os.getenv("CRYPTO_BOT_TOKEN")
 CRYPTOBOT_API = os.getenv("CRYPTOBOT_API", "https://pay.crypt.bot/api")
 
 STATUS_MAP = {

--- a/modules/payments/service.py
+++ b/modules/payments/service.py
@@ -14,7 +14,7 @@ from . import InvoiceResponse, ProviderError
 log = logging.getLogger("juicyfox.payments.service")
 
 # --- Провайдеры / ENV ---
-CRYPTOBOT_TOKEN = os.getenv("CRYPTOBOT_TOKEN")
+CRYPTOBOT_TOKEN = os.getenv("CRYPTOBOT_TOKEN") or os.getenv("CRYPTO_BOT_TOKEN")
 CRYPTOBOT_API = os.getenv("CRYPTOBOT_API", "https://pay.crypt.bot/api")
 PAYMENT_PROVIDER = os.getenv("PAYMENT_PROVIDER", "cryptobot").lower()
 


### PR DESCRIPTION
## Summary
- allow the payments service and provider layers to read the CryptoBot token from either CRYPTOBOT_TOKEN or CRYPTO_BOT_TOKEN

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9d4f2e3d4832ab40a523398131842