### PR TITLE
Update reply menu support buttons

### DIFF
--- a/modules/ui_membership/keyboards.py
+++ b/modules/ui_membership/keyboards.py
@@ -157,7 +157,11 @@ def reply_menu(lang: str) -> ReplyKeyboardMarkup:
             [KeyboardButton(text=chat_label)],
             # [KeyboardButton(text=luxury_label), KeyboardButton(text=vip_label)],  # temporarily hidden
             [KeyboardButton(text=vip_label)],
-            [KeyboardButton(text=donate_label)],
+            [
+                KeyboardButton(text="Support"),
+                KeyboardButton(text=donate_label),
+                KeyboardButton(text="Restart"),
+            ],
         ],
         resize_keyboard=True,
         one_time_keyboard=False,


### PR DESCRIPTION
## Summary
- add Support and Restart buttons to the reply menu alongside the existing Donate option

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9fd907568832abfc9bfd8faac8347