### PR TITLE
Extend payment idempotency to 24h

### DIFF
--- a/modules/access/__init__.py
+++ b/modules/access/__init__.py
@@ -116,7 +116,7 @@ async def process_payment_event(event: Dict[str, Any]) -> Dict[str, Any]:
         provider = str(event.get("provider") or "")
         idem_key = provider_key(provider, invoice_id or f"{user_id}:{plan_code}")
 
-        is_new = await claim_idempotency_key(idem_key)
+        is_new = await claim_idempotency_key(idem_key, ttl_seconds=86400)
         if not is_new:
             duplicate = True
             log.info("duplicate payment skipped: %s", idem_key)


### PR DESCRIPTION
## Summary
- extend the payment event idempotency reservation period to 24 hours so duplicate grants are avoided

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca2588b710832aaa740772a5e8d179